### PR TITLE
add @eslint/css and sort imports linting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.formatOnPaste": true,
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": "explicit",
-        "source.fixAll": "explicit"
+        "source.fixAll": "explicit",
     },
     "eslint.validate": [
         "javascript",
@@ -12,7 +12,7 @@
         "typescript",
         "typescriptreact",
         "json",
-        "jsonc"
+        "jsonc",
     ],
     "prettier.requireConfig": true,
     "[typescriptreact]": {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, ChangeEvent } from 'react';
-import miniMealieLogo from '/mini-mealie.svg';
 import './App.css';
+
+import { ChangeEvent, useEffect, useState } from 'react';
+
+import miniMealieLogo from '/mini-mealie.svg';
 
 enum Protocol {
     HTTP = 'http://',

--- a/entrypoints/popup/main.tsx
+++ b/entrypoints/popup/main.tsx
@@ -1,7 +1,9 @@
+import './style.css';
+
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
+
 import App from './App.tsx';
-import './style.css';
 
 function addGoogleAnalytics() {
     if (!document.getElementById('gtag-script')) {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -2,34 +2,33 @@
     font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
     line-height: 1.5;
     font-weight: 400;
-  
+
     color-scheme: light dark;
     color: #ffffff;
     background-color: #1c1c1c;
-  
-    --mealie-orange: #EC7E19;
-    --mealie-black: #1c1c1c;
+
+    --mealie-orange: #ec7e19 --mealie-black: #1c1c1c;
     --mealie-white: #ffffff;
     --mealie-grey: #2d2d2d;
     --mealie-hover: #f59849;
-  
+
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     -webkit-text-size-adjust: 100%;
-  }
-  
-  a {
+}
+
+a {
     font-weight: 500;
     color: var(--mealie-orange);
     text-decoration: inherit;
-  }
-  a:hover {
+}
+a:hover {
     color: var(--mealie-hover);
-  }
-  
-  body {
+}
+
+body {
     margin: 0;
     display: flex;
     place-items: center;
@@ -37,15 +36,15 @@
     min-height: 100vh;
     background-color: var(--mealie-black);
     color: var(--mealie-white);
-  }
-  
-  h1 {
+}
+
+h1 {
     font-size: 3.2em;
     line-height: 1.1;
     color: var(--mealie-orange);
-  }
-  
-  button {
+}
+
+button {
     border-radius: 8px;
     border: 1px solid transparent;
     padding: 0.6em 1.2em;
@@ -56,41 +55,41 @@
     color: var(--mealie-white);
     cursor: pointer;
     transition: background-color 0.25s;
-  }
-  button:hover {
+}
+button:hover {
     background-color: var(--mealie-hover);
-  }
-  button:focus,
-  button:focus-visible {
+}
+button:focus,
+button:focus-visible {
     outline: 4px auto -webkit-focus-ring-color;
-  }
-  
-  .card {
+}
+
+.card {
     background-color: var(--mealie-grey);
     border-radius: 10px;
     padding: 1em;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
     color: var(--mealie-white);
-  }
-  
-  @media (prefers-color-scheme: light) {
+}
+
+@media (prefers-color-scheme: light) {
     :root {
-      color: var(--mealie-black);
-      background-color: var(--mealie-white);
+        color: var(--mealie-black);
+        background-color: var(--mealie-white);
     }
     a:hover {
-      color: var(--mealie-hover);
+        color: var(--mealie-hover);
     }
     button {
-      background-color: var(--mealie-orange);
-      color: var(--mealie-white);
+        background-color: var(--mealie-orange);
+        color: var(--mealie-white);
     }
     body {
-      background-color: var(--mealie-white);
-      color: var(--mealie-black);
+        background-color: var(--mealie-white);
+        color: var(--mealie-black);
     }
     .card {
-      background-color: #f4f4f4;
-      color: var(--mealie-black);
+        background-color: #f4f4f4;
+        color: var(--mealie-black);
     }
-  }
+}

--- a/entrypoints/popup/tests/App.test.tsx
+++ b/entrypoints/popup/tests/App.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('isLoggedIn', () => {
     beforeEach(() => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,32 @@
+import css from '@eslint/css';
 import pluginJs from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import pluginReact from 'eslint-plugin-react';
 import pluginSecurity from 'eslint-plugin-security';
+import importSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
+
 import autoImports from './.wxt/eslint-auto-imports.mjs';
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-    // { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx,css,html}"], // TODO: add css once @eslint/css 0.5.0 is
+    { ...pluginJs.configs.recommended, files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
+    ...tseslint.configs.recommended.map((config) => ({
+        ...config,
+        files: ['**/*.{js,ts,jsx,tsx}'],
+    })),
+    { ...pluginReact.configs.flat.recommended, files: ['**/*.{js,ts,jsx,tsx}'] },
+    {
+        files: ['**/*.{js,ts,jsx,tsx}'],
+        plugins: {
+            'simple-import-sort': importSort,
+        },
+        rules: {
+            'simple-import-sort/imports': 'error',
+            'simple-import-sort/exports': 'error',
+        },
+    },
     {
         files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
         languageOptions: { globals: globals.browser },
@@ -18,18 +36,24 @@ export default [
                 'jsx-runtime': 'automatic',
             },
         },
-    },
-    pluginJs.configs.recommended,
-    ...tseslint.configs.recommended,
-    pluginReact.configs.flat.recommended,
-    {
         rules: {
             'react/react-in-jsx-scope': 'off',
             'react/jsx-no-undef': ['error', { allowGlobals: true }],
         },
     },
-    pluginSecurity.configs.recommended,
-    eslintPluginPrettierRecommended,
+    {
+        files: ['**/*.css'],
+        language: 'css/css',
+        plugins: {
+            css,
+        },
+        rules: {
+            ...css.configs.recommended.rules,
+            'css/require-baseline': 'off',
+        },
+    },
+    { ...pluginSecurity.configs.recommended, files: ['**/*.{js,ts,jsx,tsx}'] },
+    { ...eslintPluginPrettierRecommended, files: ['**/*.{js,ts,jsx,tsx}'] },
     autoImports,
     {
         ignores: ['node_modules', '.wxt', '.output', 'coverage', 'html', 'coverage-report'],

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "react-dom": "^19.0.0"
     },
     "devDependencies": {
+        "@eslint/css": "^0.5.0",
         "@eslint/js": "^9.22.0",
         "@html-eslint/parser": "^0.35.2",
         "@types/chrome": "^0.0.280",
@@ -40,6 +41,7 @@
         "eslint-plugin-prettier": "^5.2.3",
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-security": "^3.0.1",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "globals": "^16.0.0",
         "prettier": "^3.5.3",
         "typescript": "^5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
     devDependencies:
+      '@eslint/css':
+        specifier: ^0.5.0
+        version: 0.5.0
       '@eslint/js':
         specifier: ^9.22.0
         version: 9.22.0
@@ -60,6 +63,9 @@ importers:
       eslint-plugin-security:
         specifier: ^3.0.1
         version: 3.0.1
+      eslint-plugin-simple-import-sort:
+        specifier: ^12.1.1
+        version: 12.1.1(eslint@9.22.0(jiti@2.4.2))
       globals:
         specifier: ^16.0.0
         version: 16.0.0
@@ -366,8 +372,20 @@ packages:
     resolution: {integrity: sha512-kLrdPDJE1ckPo94kmPPf9Hfd0DU0Jw6oKYrhe+pwSC0iTUInmTa+w6fw8sGgcfkFJGNdWOUeOaDM4quW4a7OkA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/core@0.10.0':
+    resolution: {integrity: sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/core@0.12.0':
     resolution: {integrity: sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/css-tree@3.3.0':
+    resolution: {integrity: sha512-tJp1UEhb1q4B2o45MXEOi3OtLAh3ovtwJDzGCd723VN04heVQ/J/0oMJQabMGopsbz9A8vLUfswzn16gza7FUg==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  '@eslint/css@0.5.0':
+    resolution: {integrity: sha512-40n/DbZuJwYe15u64BCck1wU4X67wgvoejiOrc4GKJeFojv2jVZvy7zU2rYADxglCXn/US8SreXSrAsNJDSKFg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.0':
@@ -1384,6 +1402,11 @@ packages:
     resolution: {integrity: sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-plugin-simple-import-sort@12.1.1:
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
+
   eslint-scope@8.3.0:
     resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2174,6 +2197,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.18.0:
+    resolution: {integrity: sha512-gtCy1yim/vpHF/tq3B4Z43x3zKWpYeb4IM3d/Mf4oMYcNuoXOYEaqtoFlLHw9zd7+WNN3jNh6/WXyUrD3OIiwQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3571,9 +3597,24 @@ snapshots:
 
   '@eslint/config-helpers@0.1.0': {}
 
+  '@eslint/core@0.10.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
   '@eslint/core@0.12.0':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/css-tree@3.3.0':
+    dependencies:
+      mdn-data: 2.18.0
+      source-map-js: 1.2.1
+
+  '@eslint/css@0.5.0':
+    dependencies:
+      '@eslint/core': 0.10.0
+      '@eslint/css-tree': 3.3.0
+      '@eslint/plugin-kit': 0.2.7
 
   '@eslint/eslintrc@3.3.0':
     dependencies:
@@ -4727,6 +4768,10 @@ snapshots:
     dependencies:
       safe-regex: 2.1.1
 
+  eslint-plugin-simple-import-sort@12.1.1(eslint@9.22.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.22.0(jiti@2.4.2)
+
   eslint-scope@8.3.0:
     dependencies:
       esrecurse: 4.3.0
@@ -5568,6 +5613,8 @@ snapshots:
   marky@1.2.5: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.18.0: {}
 
   merge-stream@2.0.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
-  "extends": "./.wxt/tsconfig.json",
-  "compilerOptions": {
-    "allowImportingTsExtensions": true,
-    "jsx": "react-jsx"
-  }
+    "extends": "./.wxt/tsconfig.json",
+    "compilerOptions": {
+        "allowImportingTsExtensions": true,
+        "jsx": "react-jsx"
+    },
+    "typescript.preferences.importModuleSpecifier": "shortest",
+    "typescript.preferences.autoImportFileExcludePatterns": ["node_modules"]
 }

--- a/utils/tests/badge.test.ts
+++ b/utils/tests/badge.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mocking the Chrome API
 beforeEach(() => {

--- a/utils/tests/contextMenu.test.ts
+++ b/utils/tests/contextMenu.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mocking the Chrome API
 beforeEach(() => {

--- a/utils/tests/network.test.ts
+++ b/utils/tests/network.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../badge', () => ({
     showBadge: vi.fn(),

--- a/utils/tests/storage.test.ts
+++ b/utils/tests/storage.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { checkStorageAndUpdateBadge } from '../storage';
-import { showBadge, clearBadge } from '../badge';
-import { addContextMenu, removeContextMenu } from '../contextMenu';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WxtVitest } from 'wxt/testing';
+
+import { clearBadge, showBadge } from '../badge';
+import { addContextMenu, removeContextMenu } from '../contextMenu';
+import { checkStorageAndUpdateBadge } from '../storage';
 
 // Enable WxtVitest for Web Extension APIs
 WxtVitest();


### PR DESCRIPTION
ESLint recently introduced support for parsing and linting CSS files! This PR adds the necessary dependencies and updates the ESLint configuration to enable CSS linting. To comply with the new rules, it also applies linting to existing CSS files.

Additionally, this PR includes a package that helps ESLint automatically sort import statements at the top of code files. While this might seem like a minor improvement, it enhances code consistency and maintainability.