### PR TITLE
update to issues-raw url

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Distributed under the AGPL License. See LICENSE for more information.
 [contributors-url]: https://github.com/mrshappy0/mini-mealie/graphs/contributors
 [stars-shield]: https://img.shields.io/github/stars/mrshappy0/mini-mealie.svg?style=for-the-badge
 [stars-url]: https://github.com/mrshappy0/mini-mealie/stargazers
-[issues-shield]: https://img.shields.io/github/issues/mrshappy0/mini-mealie.svg?style=for-the-badge
+[issues-shield]: https://img.shields.io/github/issues-raw/mrshappy0/mini-mealie.svg?style=for-the-badge
 [issues-url]: https://github.com/mrshappy0/mini-mealie/issues
 [license-shield]: https://img.shields.io/github/license/mrshappy0/mini-mealie.svg?style=for-the-badge
 [license-url]: https://github.com/mrshappy0/mini-mealie/blob/main/LICENSE


### PR DESCRIPTION
##  Fix Open Issues Badge in README

### What’s Changed
- **Replaced** the Shields.io open‑issues badge URL from the GraphQL‑powered endpoint:
  ```diff
  - https://img.shields.io/github/issues/mrshappy0/mini-mealie.svg?style=for-the-badge