### PR TITLE
Add 13ft Ladder Paywall Jumper Integration for Recipe Scraping

### DIFF
--- a/entrypoints/popup/App.css
+++ b/entrypoints/popup/App.css
@@ -133,7 +133,7 @@
     background-color: var(--mealie-orange);
     color: #000000;
     text-decoration: none;
-    font-family: "Poppins", sans-serif;
+    font-family: 'Poppins', sans-serif;
     font-weight: bold;
     border-radius: 6px;
     transition: background-color 0.3s ease;
@@ -180,7 +180,7 @@
 
 .slider::before {
     position: absolute;
-    content: "";
+    content: '';
     height: 14px;
     width: 14px;
     left: 3px;
@@ -218,6 +218,78 @@ input:checked + .slider::before {
 }
 
 .greeting strong {
-    color: #ffad4d;
+    color: var(--mealie-orange);
     font-weight: 600;
+}
+
+.ladder-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: left;
+    margin: 1em 0;
+    font-size: 1.1em;
+    color: grey;
+}
+
+.ladder-toggle label {
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+    cursor: pointer;
+    transition: color 0.3s ease;
+}
+
+.ladder-toggle label:hover {
+    color: var(--mealie-orange);
+}
+
+.ladder-toggle label:hover input[type='checkbox'] {
+    background-color: #555;
+    border-color: var(--mealie-orange);
+}
+
+.ladder-toggle input[type='checkbox'] {
+    all: unset;
+    appearance: none;
+    width: 2.6em;
+    height: 1.4em;
+    background-color: #444;
+    border: 1.5px solid #444;
+    border-radius: 9999px;
+    position: relative;
+    top: 0.05em;
+    display: inline-block;
+    vertical-align: middle;
+    line-height: 0;
+    flex-shrink: 0;
+    padding: 0;
+    transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.ladder-toggle input[type='checkbox']:checked {
+    background-color: #444;
+}
+
+.ladder-toggle input[type='checkbox']::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0.15em;
+    transform: translateY(-50%);
+    width: 1.1em;
+    height: 1.1em;
+    background-color: var(--mealie-grey);
+    border-radius: 50%;
+    transition: transform 0.25s ease, background-color 0.25s ease;
+}
+
+/* Knob checked state */
+.ladder-toggle input[type='checkbox']:checked::before {
+    transform: translate(1.1em, -50%);
+    background-color: var(--mealie-orange);
+}
+
+/* Label text color when checked */
+.ladder-toggle input[type='checkbox']:checked + span {
+    color: var(--mealie-white);
 }

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -14,18 +14,23 @@ function App() {
     const [username, setUsername] = useState<string | undefined>();
     const [error, setError] = useState(false);
     const [loading, setLoading] = useState(false);
+    const [ladderEnabled, setLadderEnabled] = useState(true);
+
+    const handleToggleLadder = () => {
+        const newValue = !ladderEnabled;
+        setLadderEnabled(newValue);
+        chrome.storage.sync.set({ ladderEnabled: newValue });
+    };
 
     useEffect(() => {
         chrome.storage.sync.get<StorageData>(
             [...storageKeys],
-            ({ mealieServer, mealieApiToken, mealieUsername }: StorageData) => {
-                if (mealieServer) {
-                    setMealieServer(mealieServer);
-                }
+            ({ mealieServer, mealieApiToken, mealieUsername, ladderEnabled }: StorageData) => {
+                if (mealieServer) setMealieServer(mealieServer);
                 setInputServer(protocol);
-
                 if (mealieApiToken) setMealieApiToken(mealieApiToken);
                 if (mealieUsername) setUsername(mealieUsername);
+                if (ladderEnabled) setLadderEnabled(ladderEnabled);
             },
         );
     }, [protocol]);
@@ -48,11 +53,12 @@ function App() {
             clearSettings();
             return;
         }
-        chrome.storage.sync.set<StorageData>(
+        chrome.storage.sync.set(
             {
                 mealieServer: inputServer,
                 mealieApiToken: inputToken,
                 mealieUsername: result.username,
+                ladderEnabled: false,
             },
             () => {
                 setMealieServer(inputServer);
@@ -173,6 +179,20 @@ function App() {
                     </>
                 ) : (
                     <>
+                        <div className="ladder-toggle">
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    checked={ladderEnabled}
+                                    onChange={handleToggleLadder}
+                                />
+                                <span>
+                                    {ladderEnabled
+                                        ? 'Paywall Ladder Enabled'
+                                        : 'Paywall Ladder Disabled'}
+                                </span>
+                            </label>
+                        </div>
                         <div className="connected-message">
                             <p className="greeting">
                                 Hi <strong>{username}</strong> — your server is connected!

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mini-mealie",
     "description": "manifest.json description",
     "private": true,
-    "version": "0.3.0",
+    "version": "0.4.0",
     "type": "module",
     "scripts": {
         "dev": "wxt",

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -1,7 +1,8 @@
 export const runCreateRecipe = (url: string, tabId: number) => {
     chrome.storage.sync.get<StorageData>(
         [...storageKeys],
-        ({ mealieServer, mealieApiToken }: StorageData) => {
+        ({ mealieServer, mealieApiToken, ladderEnabled }: StorageData) => {
+            console.log(ladderEnabled);
             if (!mealieServer || !mealieApiToken) {
                 showBadge('❌', 4);
                 return;
@@ -10,17 +11,30 @@ export const runCreateRecipe = (url: string, tabId: number) => {
             const scriptParams = {
                 target: { tabId },
                 func: createRecipe,
-                args: [url, mealieServer, mealieApiToken] as [string, string, string],
+                args: [url, mealieServer, mealieApiToken, ladderEnabled] as [
+                    string,
+                    string,
+                    string,
+                    boolean,
+                ],
             };
-
+            console.log('hoitjhoiwe: ', ladderEnabled, typeof ladderEnabled);
             chrome.scripting.executeScript(scriptParams, (result) => {
+                console.log('result', result);
                 showBadge(result[0].result === 'success' ? '✅' : '❌', 4);
             });
         },
     );
 };
 
-async function createRecipe(url: string, server: string, token: string): Promise<string> {
+async function createRecipe(
+    url: string,
+    server: string,
+    token: string,
+    ladderEnabled: boolean,
+): Promise<string> {
+    const ladderUrl = 'https://13ft.wasimaster.me';
+    const finalUrl = ladderEnabled ? `${ladderUrl}/${url}` : url;
     try {
         const response = await fetch(`${server}/api/recipes/create/url`, {
             method: 'POST',
@@ -28,7 +42,7 @@ async function createRecipe(url: string, server: string, token: string): Promise
                 Authorization: `Bearer ${token}`,
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ url }),
+            body: JSON.stringify({ url: finalUrl }),
         });
 
         if (!response.ok) {

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -2,7 +2,6 @@ export const runCreateRecipe = (url: string, tabId: number) => {
     chrome.storage.sync.get<StorageData>(
         [...storageKeys],
         ({ mealieServer, mealieApiToken, ladderEnabled }: StorageData) => {
-            console.log(ladderEnabled);
             if (!mealieServer || !mealieApiToken) {
                 showBadge('❌', 4);
                 return;
@@ -18,9 +17,7 @@ export const runCreateRecipe = (url: string, tabId: number) => {
                     boolean,
                 ],
             };
-            console.log('hoitjhoiwe: ', ladderEnabled, typeof ladderEnabled);
             chrome.scripting.executeScript(scriptParams, (result) => {
-                console.log('result', result);
                 showBadge(result[0].result === 'success' ? '✅' : '❌', 4);
             });
         },

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -24,7 +24,7 @@ export const runCreateRecipe = (url: string, tabId: number) => {
     );
 };
 
-async function createRecipe(
+export async function createRecipe(
     url: string,
     server: string,
     token: string,

--- a/utils/types/storageTypes.ts
+++ b/utils/types/storageTypes.ts
@@ -1,3 +1,8 @@
-export const storageKeys = ['mealieServer', 'mealieApiToken', 'mealieUsername'] as const;
+export const storageKeys = [
+    'mealieServer',
+    'mealieApiToken',
+    'mealieUsername',
+    'ladderEnabled',
+] as const;
 type StorageKey = (typeof storageKeys)[number];
-export type StorageData = Partial<Record<StorageKey, string>>;
+export type StorageData = Partial<Record<StorageKey, string> & Record<'ladderEnabled', boolean>>;


### PR DESCRIPTION
This PR introduces optional integration with [13ft Ladder](https://github.com/wasi-master/13ft), an open-source paywall jumper, to enhance recipe scraping capabilities in the Mini Mealie extension.

While Mealie already appears to handle some paywall circumvention internally (exact implementation unknown), this feature provides an additional layer for sites that remain restricted or inaccessible during standard scraping.

### Key Features
	•	Optional Paywall Jumper Toggle:
	•	Added a user-facing toggle in the extension popup to enable or disable 13ft Ladder for recipe scraping.
	•	Toggle state is persisted via chrome.storage.sync.
	•	Ladder URL Injection:
	•	When the toggle is enabled, the target recipe URL is prefixed with the configured 13ft Ladder instance (e.g., https://13ft.wasimaster.me/https://cooking.nytimes.com/...).
	•	This allows scraping as if the request originates from a Google SEO bot, bypassing common paywalls.
	•	When the toggle is off, the extension sends the original recipe URL directly to Mealie without modification.

### Future Considerations
	•	Custom Ladder Instance Configuration:
	•	Currently hardcoded to https://13ft.wasimaster.me.
	•	Future work could allow users to configure their own Ladder instance for more control.
	•	Understanding Mealie’s approach could help optimize or avoid redundant layers.