### PR TITLE
repair toggle not persisting

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -30,7 +30,7 @@ function App() {
                 setInputServer(protocol);
                 if (mealieApiToken) setMealieApiToken(mealieApiToken);
                 if (mealieUsername) setUsername(mealieUsername);
-                if (ladderEnabled) setLadderEnabled(ladderEnabled);
+                setLadderEnabled(ladderEnabled ?? true);
             },
         );
     }, [protocol]);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mini-mealie",
     "description": "manifest.json description",
     "private": true,
-    "version": "0.4.1",
+    "version": "0.4.2",
     "type": "module",
     "scripts": {
         "dev": "wxt",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     modules: ['@wxt-dev/module-react'],
     manifest: {
         permissions: ['storage', 'activeTab', 'contextMenus', 'scripting'],
+        origins: ['<all_urls>'],
         description: 'Scrape recipes and save them to a Mealie instance.',
         name: 'Mini Mealie',
     },


### PR DESCRIPTION
Upon refresh, your paywall toggle state would always reset to true. Since the paywall toggle isn't perfect, I think we want to avoid doing this and might even remove this some day soon entirely. Should consider setting it to default to false (off).