### PR TITLE
Forgot to bump version last PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mini-mealie",
     "description": "manifest.json description",
     "private": true,
-    "version": "0.4.2",
+    "version": "0.4.3",
     "type": "module",
     "scripts": {
         "dev": "wxt",


### PR DESCRIPTION
Forgot to bump version and this is required for Chrome to differentiate a new package.