### PR TITLE
fix(release): add explicit releaseRules to trigger releases for refac…

### DIFF
--- a/.github/prompts/cz.prompt.md
+++ b/.github/prompts/cz.prompt.md
@@ -9,34 +9,43 @@ You are GitHub Copilot Chat inside VS Code. Your job is to generate a high-quali
 - **Only** inspect **staged** changes. Never base the message on unstaged changes.
 - Never commit automatically. **Do not run `git commit`** until the user explicitly says: **“commit those changes”**.
 - Enforce Conventional Commits format strictly:
-  - Header: `type(scope): subject`
-  - `type` must be one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
-  - `scope` is optional but preferred when it adds clarity (e.g. `utils`, `popup`, `background`, `deps`).
-  - `subject`:
-    - imperative mood (e.g. “add”, “fix”, “update”)
-    - no trailing period
-    - concise (aim <= 72 chars)
+    - Header: `type(scope): subject`
+    - `type` must be one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+        - **Release-triggering types** (per `.releaserc`):
+            - `feat` → minor release
+            - `fix` → patch release
+            - `refactor` → patch release
+            - `perf` → patch release
+            - `revert` → patch release
+        - **Non-releasing types**: `test`, `docs`, `chore`, `style`, `ci`, `build`
+        - When a change includes a user-facing fix or behavior change, prefer `fix` or `refactor` over `chore`/`style`/`test` so a release is triggered.
+    - `scope` is optional but preferred when it adds clarity (e.g. `utils`, `popup`, `background`, `deps`).
+    - `subject`:
+        - imperative mood (e.g. “add”, “fix”, “update”)
+        - no trailing period
+        - concise (aim <= 72 chars)
 - If changes include a breaking change, mark it:
-  - header includes `!` (e.g. `feat(utils)!: ...`) AND
-  - include `BREAKING CHANGE: ...` in the footer.
+    - header includes `!` (e.g. `feat(utils)!: ...`) AND
+    - include `BREAKING CHANGE: ...` in the footer.
 - If you cannot determine scope/type confidently, ask 1–2 short clarifying questions.
 
 ## Workflow
 
 1. Gather staged changes:
-   - Run `git status --porcelain=v1`.
-   - Run `git diff --staged`.
+    - Run `git status --porcelain=v1`.
+    - Run `git diff --staged`.
 2. Summarize what the staged change does in 2–4 bullets.
 3. Propose a Conventional Commit message:
-   - Provide the **exact** header line.
-   - Provide an optional body (wrap at ~72 chars) explaining **why**, not just what.
-   - Provide footers only if needed (e.g. `BREAKING CHANGE:` or issue refs).
+    - Provide the **exact** header line.
+    - Provide an optional body (wrap at ~72 chars) explaining **why**, not just what.
+    - Provide footers only if needed (e.g. `BREAKING CHANGE:` or issue refs).
 4. Ask the user to review:
-   - “Do you want to tweak type/scope/subject/body, or should I commit those changes?”
+    - “Do you want to tweak type/scope/subject/body, or should I commit those changes?”
 5. Iterate until the user says **“commit those changes”**.
 6. Only then, immediately perform the commit using the final message.
-  - Use the exact content of the generated commit message (the fenced `text` code block).
-  - Do not add extra text, quotes, or prefixes.
+
+- Use the exact content of the generated commit message (the fenced `text` code block).
+- Do not add extra text, quotes, or prefixes.
 
 ## Guardrails for committing
 
@@ -47,15 +56,15 @@ You are GitHub Copilot Chat inside VS Code. Your job is to generate a high-quali
 ## Output format when proposing the message
 
 - First, label the parts:
-  - `Header:` (single line)
-  - `Body:` (optional)
-  - `Footers:` (optional)
+    - `Header:` (single line)
+    - `Body:` (optional)
+    - `Footers:` (optional)
 - Then output a single, copy/paste-ready commit message in a fenced code block that will satisfy commitlint/Conventional Commits parsing:
-  - Use language `text` for the fence.
-  - The first line must be the exact header.
-  - If there is a body, include a blank line after the header, then the body.
-  - If there are footers, include a blank line after the body (or after the header if no body), then the footers.
-  - Footers must use standard tokens like `BREAKING CHANGE: ...` or `Refs: ...` / `Closes: ...`.
-  - Do not wrap the message in quotes.
+    - Use language `text` for the fence.
+    - The first line must be the exact header.
+    - If there is a body, include a blank line after the header, then the body.
+    - If there are footers, include a blank line after the body (or after the header if no body), then the footers.
+    - Footers must use standard tokens like `BREAKING CHANGE: ...` or `Refs: ...` / `Closes: ...`.
+    - Do not wrap the message in quotes.
 
 Start now by inspecting staged changes.

--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,49 @@
         "main"
     ],
     "plugins": [
-        "@semantic-release/commit-analyzer",
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "releaseRules": [
+                    {
+                        "type": "refactor",
+                        "release": "patch"
+                    },
+                    {
+                        "type": "perf",
+                        "release": "patch"
+                    },
+                    {
+                        "type": "test",
+                        "release": false
+                    },
+                    {
+                        "type": "docs",
+                        "release": false
+                    },
+                    {
+                        "type": "chore",
+                        "release": false
+                    },
+                    {
+                        "type": "style",
+                        "release": false
+                    },
+                    {
+                        "type": "ci",
+                        "release": false
+                    },
+                    {
+                        "type": "build",
+                        "release": false
+                    },
+                    {
+                        "type": "revert",
+                        "release": "patch"
+                    }
+                ]
+            }
+        ],
         "@semantic-release/release-notes-generator",
         [
             "@semantic-release/npm",


### PR DESCRIPTION
…tor commits

Add releaseRules to .releaserc so refactor, perf, and revert commits trigger patch releases. Without this, user-facing changes committed with non-default typ