### PR TITLE
chore: use workspace typescript in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.formatOnPaste": true,
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": "explicit",
-        "source.fixAll": "explicit",
+        "source.fixAll": "explicit"
     },
     "eslint.validate": [
         "javascript",
@@ -12,7 +12,7 @@
         "typescript",
         "typescriptreact",
         "json",
-        "jsonc",
+        "jsonc"
     ],
     "prettier.requireConfig": true,
     "[typescriptreact]": {
@@ -23,5 +23,6 @@
     },
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
-    }
+    },
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## Use workspace TypeScript in VS Code

Adds `js/ts.tsdk.path` to `.vscode/settings.json` pointing to `node_modules/typescript/lib`, and cleans up trailing commas.

This fixes a false `Cannot find namespace 'chrome'` error in IntelliSense caused by VS Code's bundled TypeScript not correctly resolving `package.json` `exports` fields (needed for `wxt/vite-builder-env` types to resolve and pull in `@types/chrome`).

No code changes. No release triggered.