### PR TITLE
fix(recipe-create): fetch group slug live from API instead of caching in storage

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -110,27 +110,39 @@ export default defineBackground(() => {
  * Opens the recipe page directly in Mealie.
  */
 async function handleViewSpecificDuplicate(slug: string) {
-    // Get server and group slug from storage
     chrome.storage.sync.get([...storageKeys], async (data) => {
-        const { mealieServer, mealieGroupSlug } = data;
+        const { mealieServer, mealieApiToken } = data;
 
-        if (!mealieServer || !mealieGroupSlug) {
+        if (!mealieServer || !mealieApiToken) {
             await logEvent({
                 level: 'warn',
                 feature: 'duplicate-detect',
                 action: 'viewSpecificDuplicate',
                 phase: 'failure',
-                message: 'Missing server or group slug',
+                message: 'Missing server or token',
                 data: {
                     hasMealieServer: !!mealieServer,
-                    hasMealieGroupSlug: !!mealieGroupSlug,
+                    hasMealieApiToken: !!mealieApiToken,
                 },
             });
             return;
         }
 
-        // Open the specific recipe page
-        const recipeUrl = `${mealieServer}/g/${mealieGroupSlug}/r/${slug}`;
+        const user = await getUser(mealieServer, mealieApiToken);
+        const groupSlug = 'groupSlug' in user ? user.groupSlug : undefined;
+
+        if (!groupSlug) {
+            await logEvent({
+                level: 'warn',
+                feature: 'duplicate-detect',
+                action: 'viewSpecificDuplicate',
+                phase: 'failure',
+                message: 'Failed to fetch group slug',
+            });
+            return;
+        }
+
+        const recipeUrl = `${mealieServer}/g/${groupSlug}/r/${slug}`;
         await logEvent({
             level: 'info',
             feature: 'duplicate-detect',
@@ -162,21 +174,34 @@ async function handleViewDuplicate(url: string, menuId: string) {
         return;
     }
 
-    // Get server and group slug from storage
     chrome.storage.sync.get([...storageKeys], async (data) => {
-        const { mealieServer, mealieGroupSlug } = data;
+        const { mealieServer, mealieApiToken } = data;
 
-        if (!mealieServer || !mealieGroupSlug) {
+        if (!mealieServer || !mealieApiToken) {
             await logEvent({
                 level: 'warn',
                 feature: 'duplicate-detect',
                 action: 'viewDuplicate',
                 phase: 'failure',
-                message: 'Missing server or group slug',
+                message: 'Missing server or token',
                 data: {
                     hasMealieServer: !!mealieServer,
-                    hasMealieGroupSlug: !!mealieGroupSlug,
+                    hasMealieApiToken: !!mealieApiToken,
                 },
+            });
+            return;
+        }
+
+        const user = await getUser(mealieServer, mealieApiToken);
+        const groupSlug = 'groupSlug' in user ? user.groupSlug : undefined;
+
+        if (!groupSlug) {
+            await logEvent({
+                level: 'warn',
+                feature: 'duplicate-detect',
+                action: 'viewDuplicate',
+                phase: 'failure',
+                message: 'Failed to fetch group slug',
             });
             return;
         }
@@ -184,8 +209,7 @@ async function handleViewDuplicate(url: string, menuId: string) {
         const duplicateInfo = cached.duplicateDetection!;
 
         if (menuId === DUPLICATE_URL_MENU_ID && duplicateInfo.urlMatch) {
-            // Open the exact match recipe page
-            const recipeUrl = `${mealieServer}/g/${mealieGroupSlug}/r/${duplicateInfo.urlMatch.slug}`;
+            const recipeUrl = `${mealieServer}/g/${groupSlug}/r/${duplicateInfo.urlMatch.slug}`;
             await logEvent({
                 level: 'info',
                 feature: 'duplicate-detect',
@@ -199,8 +223,7 @@ async function handleViewDuplicate(url: string, menuId: string) {
             });
             void chrome.tabs.create({ url: recipeUrl });
         } else if (menuId === DUPLICATE_NAME_MENU_ID && cached.recipeName) {
-            // Open search page with recipe name
-            const searchUrl = `${mealieServer}/g/${mealieGroupSlug}/recipes/all?page=1&orderBy=created_at&orderDirection=desc&search=${encodeURIComponent(cached.recipeName)}`;
+            const searchUrl = `${mealieServer}/g/${groupSlug}/recipes/all?page=1&orderBy=created_at&orderDirection=desc&search=${encodeURIComponent(cached.recipeName)}`;
             await logEvent({
                 level: 'info',
                 feature: 'duplicate-detect',

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -128,6 +128,7 @@ async function handleViewSpecificDuplicate(slug: string) {
             return;
         }
 
+        const normalizedMealieServer = mealieServer.replace(/\/+$/, '');
         const user = await getUser(mealieServer, mealieApiToken);
         const groupSlug = 'groupSlug' in user ? user.groupSlug : undefined;
 
@@ -142,7 +143,7 @@ async function handleViewSpecificDuplicate(slug: string) {
             return;
         }
 
-        const recipeUrl = `${mealieServer}/g/${groupSlug}/r/${slug}`;
+        const recipeUrl = `${normalizedMealieServer}/g/${groupSlug}/r/${slug}`;
         await logEvent({
             level: 'info',
             feature: 'duplicate-detect',
@@ -192,6 +193,7 @@ async function handleViewDuplicate(url: string, menuId: string) {
             return;
         }
 
+        const normalizedServer = mealieServer.replace(/\/+$/, '');
         const user = await getUser(mealieServer, mealieApiToken);
         const groupSlug = 'groupSlug' in user ? user.groupSlug : undefined;
 
@@ -209,7 +211,7 @@ async function handleViewDuplicate(url: string, menuId: string) {
         const duplicateInfo = cached.duplicateDetection!;
 
         if (menuId === DUPLICATE_URL_MENU_ID && duplicateInfo.urlMatch) {
-            const recipeUrl = `${mealieServer}/g/${groupSlug}/r/${duplicateInfo.urlMatch.slug}`;
+            const recipeUrl = `${normalizedServer}/g/${encodeURIComponent(groupSlug)}/r/${encodeURIComponent(duplicateInfo.urlMatch.slug)}`;
             await logEvent({
                 level: 'info',
                 feature: 'duplicate-detect',
@@ -223,7 +225,7 @@ async function handleViewDuplicate(url: string, menuId: string) {
             });
             void chrome.tabs.create({ url: recipeUrl });
         } else if (menuId === DUPLICATE_NAME_MENU_ID && cached.recipeName) {
-            const searchUrl = `${mealieServer}/g/${groupSlug}/recipes/all?page=1&orderBy=created_at&orderDirection=desc&search=${encodeURIComponent(cached.recipeName)}`;
+            const searchUrl = `${normalizedServer}/g/${encodeURIComponent(groupSlug)}/recipes/all?page=1&orderBy=created_at&orderDirection=desc&search=${encodeURIComponent(cached.recipeName)}`;
             await logEvent({
                 level: 'info',
                 feature: 'duplicate-detect',

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -104,7 +104,6 @@ function App() {
                 mealieServer: inputServer,
                 mealieApiToken: inputToken,
                 mealieUsername: result.username,
-                mealieGroupSlug: typeof result.group === 'string' ? result.group.toLowerCase() : '',
                 ladderEnabled: false,
             },
             () => {

--- a/utils/devInit.ts
+++ b/utils/devInit.ts
@@ -67,8 +67,13 @@ export async function initDevEnvironment(): Promise<void> {
                 storageData.mealieUsername = username;
             }
 
+            const wroteUsername = Boolean(username);
             await chrome.storage.sync.set(storageData);
-            console.log('[DevInit] Storage pre-populated (without username)');
+            console.log(
+                wroteUsername
+                    ? '[DevInit] Storage pre-populated (with unverified username from .env.local)'
+                    : '[DevInit] Storage pre-populated (without username)',
+            );
         }
     } catch (error) {
         console.error('[DevInit] Error during initialization:', error);

--- a/utils/devInit.ts
+++ b/utils/devInit.ts
@@ -21,38 +21,10 @@ export async function initDevEnvironment(): Promise<void> {
     }
 
     // Check if storage already has values (don't overwrite user changes during dev)
-    const existingData = await chrome.storage.sync.get([
-        'mealieServer',
-        'mealieApiToken',
-        'mealieGroupSlug',
-    ]);
+    const existingData = await chrome.storage.sync.get(['mealieServer', 'mealieApiToken']);
 
-    // If we have all required data, skip initialization
-    if (existingData.mealieServer && existingData.mealieApiToken && existingData.mealieGroupSlug) {
-        console.log('[DevInit] Storage already populated with group slug - skipping');
-        return;
-    }
-
-    // If we have credentials but missing group slug, fetch it
-    if (existingData.mealieServer && existingData.mealieApiToken && !existingData.mealieGroupSlug) {
-        console.log('[DevInit] Storage missing group slug - fetching user profile');
-        try {
-            const { getUser } = await import('./network');
-            const userResult = await getUser(
-                existingData.mealieServer,
-                existingData.mealieApiToken,
-            );
-
-            if ('username' in userResult) {
-                await chrome.storage.sync.set({
-                    mealieUsername: userResult.username,
-                    mealieGroupSlug: userResult.group,
-                });
-                console.log('[DevInit] Added group slug to storage:', userResult.group);
-            }
-        } catch (error) {
-            console.error('[DevInit] Error fetching group slug:', error);
-        }
+    if (existingData.mealieServer && existingData.mealieApiToken) {
+        console.log('[DevInit] Storage already populated - skipping');
         return;
     }
 
@@ -71,30 +43,21 @@ export async function initDevEnvironment(): Promise<void> {
         username: username || '(not set)',
     });
 
-    // Fetch user profile to get group slug
     try {
         const { getUser } = await import('./network');
         const userResult = await getUser(server, token);
 
         if ('username' in userResult) {
-            // Populate storage with credentials and group slug
-            const storageData: Record<string, string> = {
+            await chrome.storage.sync.set({
                 mealieServer: server,
                 mealieApiToken: token,
                 mealieUsername: userResult.username,
-                mealieGroupSlug: userResult.group,
-            };
-
-            // Write to chrome.storage.sync
-            await chrome.storage.sync.set(storageData);
-
-            console.log('[DevInit] Storage pre-populated successfully with group slug:', {
+            });
+            console.log('[DevInit] Storage pre-populated successfully:', {
                 username: userResult.username,
-                group: userResult.group,
             });
         } else {
             console.warn('[DevInit] Failed to fetch user profile:', userResult.errorMessage);
-            // Fall back to setting credentials without group slug
             const storageData: Record<string, string> = {
                 mealieServer: server,
                 mealieApiToken: token,
@@ -105,7 +68,7 @@ export async function initDevEnvironment(): Promise<void> {
             }
 
             await chrome.storage.sync.set(storageData);
-            console.log('[DevInit] Storage pre-populated (without group slug)');
+            console.log('[DevInit] Storage pre-populated (without username)');
         }
     } catch (error) {
         console.error('[DevInit] Error during initialization:', error);

--- a/utils/invoke.ts
+++ b/utils/invoke.ts
@@ -4,7 +4,6 @@ export function runCreateRecipe(tab: chrome.tabs.Tab) {
         async ({
             mealieServer,
             mealieApiToken,
-            mealieGroupSlug,
             recipeCreateMode,
             importTags,
             importCategories,
@@ -101,7 +100,7 @@ export function runCreateRecipe(tab: chrome.tabs.Tab) {
                     );
 
                     if (result !== 'failure' && openAfterImport) {
-                        maybeOpenRecipeAfterImport(mealieServer, mealieGroupSlug, result.slug);
+                        await maybeOpenRecipeAfterImport(mealieServer, mealieApiToken, result.slug);
                     }
                     return;
                 }
@@ -187,7 +186,7 @@ export function runCreateRecipe(tab: chrome.tabs.Tab) {
                     );
 
                     if (result !== 'failure' && openAfterImport) {
-                        maybeOpenRecipeAfterImport(mealieServer, mealieGroupSlug, result.slug);
+                        await maybeOpenRecipeAfterImport(mealieServer, mealieApiToken, result.slug);
                     }
                     return;
                 }
@@ -196,15 +195,31 @@ export function runCreateRecipe(tab: chrome.tabs.Tab) {
     );
 }
 
-function maybeOpenRecipeAfterImport(
+async function maybeOpenRecipeAfterImport(
     mealieServer: string,
-    mealieGroupSlug: string | undefined,
+    mealieApiToken: string | undefined,
     slug: string,
 ) {
+    if (!mealieApiToken || !slug) {
+        void logEvent({
+            level: 'warn',
+            feature: 'recipe-create',
+            action: 'openAfterImport',
+            phase: 'failure',
+            message: 'Cannot open recipe: missing token or slug',
+            data: { slug },
+        });
+        return;
+    }
+
+    const user = await getUser(mealieServer, mealieApiToken);
+    const groupSlug = 'groupSlug' in user ? user.groupSlug : undefined;
+
     const recipeUrl =
-        mealieGroupSlug && slug
-            ? `${mealieServer.replace(/\/$/, '')}/g/${encodeURIComponent(mealieGroupSlug)}/r/${encodeURIComponent(slug)}`
+        groupSlug && slug
+            ? `${mealieServer.replace(/\/$/, '')}/g/${encodeURIComponent(groupSlug)}/r/${encodeURIComponent(slug)}`
             : undefined;
+
     void logEvent({
         level: recipeUrl ? 'info' : 'warn',
         feature: 'recipe-create',
@@ -212,13 +227,14 @@ function maybeOpenRecipeAfterImport(
         phase: recipeUrl ? 'success' : 'failure',
         message: recipeUrl
             ? 'Opening recipe in new tab'
-            : 'Cannot open recipe: missing slug or group',
+            : 'Cannot open recipe: failed to fetch group slug',
         data: {
             slug,
-            mealieGroupSlug,
+            groupSlug,
             recipeUrl: recipeUrl ? sanitizeUrl(recipeUrl) : undefined,
         },
     });
+
     if (recipeUrl) {
         void chrome.tabs.create({ url: recipeUrl });
     }

--- a/utils/invoke.ts
+++ b/utils/invoke.ts
@@ -213,7 +213,8 @@ async function maybeOpenRecipeAfterImport(
     }
 
     const user = await getUser(mealieServer, mealieApiToken);
-    const groupSlug = 'groupSlug' in user ? user.groupSlug : undefined;
+    const groupSlug = 'username' in user ? user.groupSlug : undefined;
+    const errorMessage = 'username' in user ? undefined : user.errorMessage;
 
     const recipeUrl =
         groupSlug && slug
@@ -231,6 +232,7 @@ async function maybeOpenRecipeAfterImport(
         data: {
             slug,
             groupSlug,
+            errorMessage,
             recipeUrl: recipeUrl ? sanitizeUrl(recipeUrl) : undefined,
         },
     });

--- a/utils/tests/invoke.test.ts
+++ b/utils/tests/invoke.test.ts
@@ -16,6 +16,16 @@ vi.mock('../logging', () => ({
 vi.mock('../network', () => ({
     createRecipeFromURL: vi.fn().mockResolvedValue({ slug: 'test-slug' }),
     createRecipeFromHTML: vi.fn().mockResolvedValue({ slug: 'test-slug' }),
+    getUser: vi.fn().mockResolvedValue({
+        username: 'testuser',
+        groupSlug: 'my-group',
+        group: 'My Group',
+        householdSlug: 'my-household',
+        household: 'My Household',
+        email: 'test@example.com',
+        fullName: 'Test User',
+        admin: false,
+    }),
 }));
 
 vi.mock('../storage', () => ({
@@ -273,7 +283,6 @@ describe('invoke', () => {
                 callback?.({
                     mealieServer: 'https://mealie.local',
                     mealieApiToken: 'token',
-                    mealieGroupSlug: 'my-group',
                     recipeCreateMode: RecipeCreateMode.URL,
                     openAfterImport: true,
                 });
@@ -301,7 +310,6 @@ describe('invoke', () => {
                 callback?.({
                     mealieServer: 'https://mealie.local',
                     mealieApiToken: 'token',
-                    mealieGroupSlug: 'my-group',
                     recipeCreateMode: RecipeCreateMode.URL,
                     openAfterImport: false,
                 });
@@ -327,7 +335,6 @@ describe('invoke', () => {
                 callback?.({
                     mealieServer: 'https://mealie.local',
                     mealieApiToken: 'token',
-                    mealieGroupSlug: 'my-group',
                     recipeCreateMode: RecipeCreateMode.URL,
                     openAfterImport: true,
                 });
@@ -353,7 +360,6 @@ describe('invoke', () => {
                 callback?.({
                     mealieServer: 'https://mealie.local',
                     mealieApiToken: 'token',
-                    mealieGroupSlug: 'my-group',
                     recipeCreateMode: RecipeCreateMode.URL,
                     openAfterImport: true,
                 });
@@ -377,7 +383,6 @@ describe('invoke', () => {
                 callback?.({
                     mealieServer: 'https://mealie.local',
                     mealieApiToken: 'token',
-                    mealieGroupSlug: 'my-group',
                     recipeCreateMode: RecipeCreateMode.HTML,
                     openAfterImport: true,
                 });
@@ -403,7 +408,6 @@ describe('invoke', () => {
                 callback?.({
                     mealieServer: 'https://mealie.local',
                     mealieApiToken: 'token',
-                    mealieGroupSlug: 'my-group',
                     recipeCreateMode: RecipeCreateMode.HTML,
                     openAfterImport: true,
                 });

--- a/utils/types/apiTypes.ts
+++ b/utils/types/apiTypes.ts
@@ -3,6 +3,7 @@ export interface User {
     email: string;
     fullName: string;
     group: string;
+    groupSlug: string;
     household: string;
     username: string;
 }

--- a/utils/types/storageTypes.ts
+++ b/utils/types/storageTypes.ts
@@ -12,7 +12,6 @@ export const storageKeys = [
     'mealieServer',
     'mealieApiToken',
     'mealieUsername',
-    'mealieGroupSlug',
     'recipeCreateMode',
     'suggestHtmlMode',
     'importTags',
@@ -24,7 +23,6 @@ export type StorageData = {
     mealieServer?: string;
     mealieApiToken?: string;
     mealieUsername?: string;
-    mealieGroupSlug?: string;
     recipeCreateMode?: RecipeCreateMode;
     suggestHtmlMode?: boolean;
     importTags?: boolean;


### PR DESCRIPTION
## Summary

Thank you for merging PR #60! While testing the published extension against a non-default Mealie instance, I discovered two issues with the group slug handling introduced in that PR.

**Problem 1 — wrong API field used**

`GET /api/users/self` returns two separate fields: `group` (the display name, e.g. `"Home"`) and `groupSlug` (the actual URL slug, e.g. `"home"` or whatever was set at group creation time). The previous implementation used `group.toLowerCase()` as a proxy for the slug. On a default Mealie installation these happen to match, but on any instance where the slug differs from the lowercased name the constructed URL is wrong and the tab opens a 404.

**Problem 2 — stale cache**

The slug was persisted in `chrome.storage.sync` at login time and never refreshed. If a user renames their group in Mealie, the stored value silently goes stale — every subsequent open-after-import or duplicate-detection click navigates to the wrong URL, with no indication of why and no recovery path short of re-saving the extension settings.

## Changes

- Read `groupSlug` (not `group`) from the `UserOut` response — Mealie serialises it as camelCase via its `alias_generator`
- Remove `mealieGroupSlug` from `StorageData`, `storageKeys`, `App.tsx` save handler, and `devInit` entirely — the slug is no longer cached
- Call `GET /api/users/self` fresh on each use: once after a successful import (when `openAfterImport` is enabled) and once when the user clicks a duplicate-detection context menu item — the extra round-trip is negligible given that a Mealie API call has just completed
- Update tests to mock `getUser` instead of the storage key

## Tests

All 190 existing tests pass. No new test cases were required — the existing `openAfterImport` suite covers the relevant paths; only the mock setup changed (`getUser` mock added, `mealieGroupSlug` removed from storage mocks).

I genuinely believe the open-after-import feature will be a favourite among users — it's one of those small touches that makes the whole workflow feel much more fluid. Hope this fix helps get it working reliably for everyone.