### PR TITLE
chore(ci): upgrade actions to Node.js 24 runtime versions

### DIFF
--- a/.github/workflows/audit-scheduled.yml
+++ b/.github/workflows/audit-scheduled.yml
@@ -15,13 +15,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'
@@ -37,7 +37,7 @@ jobs:
 
             - name: Create issue on failure
               if: failure()
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       await github.rest.issues.create({

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Review Dependency Changes
               uses: actions/dependency-review-action@v4

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,15 +11,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,13 +11,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,13 +11,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,13 @@ jobs:
 
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'

--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -10,13 +10,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -11,13 +11,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -14,13 +14,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'


### PR DESCRIPTION
- actions/checkout: v4 → v6
- actions/setup-node: v4 → v6
- pnpm/action-setup: v4 → v6
- actions/github-script: v7 → v8

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2nd, 2026, with removal on September 16th, 2026.

Refs: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/