### PR TITLE
fix(ci): add explicit permissions to all workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,6 +5,10 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     commitlint:
         name: Run Commitlint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     coverage:
         name: Check Code Coverage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: Run ESLint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     semantic-release:
         runs-on: ubuntu-latest

--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -5,6 +5,9 @@ on:
     release:
         types: [published]
 
+permissions:
+    contents: read
+
 jobs:
     email:
         runs-on: ubuntu-latest

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -5,6 +5,9 @@ on:
     release:
         types: [published]
 
+permissions:
+    contents: read
+
 jobs:
     submit:
         name: Submit to Store(s)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     test:
         name: Run Tests


### PR DESCRIPTION
## Summary

Addresses all 7 open CodeQL `actions/missing-workflow-permissions` alerts by adding explicit `permissions` blocks to each workflow.

## Alerts fixed

- https://github.com/mrshappy0/mini-mealie/security/code-scanning/1
- https://github.com/mrshappy0/mini-mealie/security/code-scanning/2
- https://github.com/mrshappy0/mini-mealie/security/code-scanning/3
- https://github.com/mrshappy0/mini-mealie/security/code-scanning/4
- https://github.com/mrshappy0/mini-mealie/security/code-scanning/5
- https://github.com/mrshappy0/mini-mealie/security/code-scanning/6
- https://github.com/mrshappy0/mini-mealie/security/code-scanning/7

## Changes

Each workflow now declares the minimum required `permissions`:

| Workflow | Permissions added |
|---|---|
| `commitlint.yml` | `contents: read`, `pull-requests: read` |
| `coverage.yml` | `contents: read` |
| `lint.yml` | `contents: read` |
| `test.yml` | `contents: read` |
| `release.yml` | `contents: read` |
| `submit.yml` | `contents: read` |
| `send-newsletter.yml` | `contents: read` |

Write operations in `release.yml` and `submit.yml` are performed via external PATs/secrets, so the default `GITHUB_TOKEN` only needs read access.