### PR TITLE
fix(build): clean Chrome _metadata folder after each build

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,3 +1,6 @@
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import { defineConfig } from 'wxt';
 
 // See https://wxt.dev/api/config.html
@@ -12,5 +15,14 @@ export default defineConfig({
     // https://wxt.dev/guide/essentials/config/auto-imports.html
     imports: {
         eslintrc: { enabled: 9 },
+    },
+    hooks: {
+        // Chrome creates a `_metadata/` folder inside the extension output directory after
+        // loading an unpacked extension. On the next build/reload Chrome then refuses to
+        // load the extension with "Filenames starting with '_' are reserved for use by the
+        // system." Deleting it after each build keeps the directory clean for Chrome.
+        'build:done': async (wxt) => {
+            await rm(join(wxt.config.outDir, '_metadata'), { recursive: true, force: true });
+        },
     },
 });


### PR DESCRIPTION
## Problem

Chrome creates a `_metadata/` directory inside the unpacked extension output directory (`.output/chrome-mv3/`) after loading it via **Load unpacked**. On the next build or dev reload, Chrome refuses to load the extension with:

> Cannot load extension with file or directory name _metadata. Filenames starting with "_" are reserved for use by the system.

This is a dev/unpacked-extension-only issue — Web Store users are not affected.

## Fix

Add a `build:done` hook to `wxt.config.ts` that deletes `_metadata` from the output directory after every build, keeping it clean for Chrome's next reload.

## Testing

Manually verified locally:
1. `pnpm build` — `.output/chrome-mv3/` created, no `_metadata`
2. `mkdir .output/chrome-mv3/_metadata` — simulates what Chrome does after loading
3. `pnpm build` again — `_metadata` is gone (hook cleaned it up) ✅