### PR TITLE
fix(deps): update brace-expansion to 5.0.6 via parent-scoped pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,9 @@
         "wxt": "^0.20.26"
     },
     "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
-    "pnpm": {}
+    "pnpm": {
+        "overrides": {
+            "minimatch@10.2.5>brace-expansion": "^5.0.6"
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -61,8 +61,12 @@
     },
     "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
     "pnpm": {
-        "overrides": {
-            "minimatch@10.2.5>brace-expansion": "^5.0.6"
+        "packageExtensions": {
+            "minimatch@10.2.5": {
+                "dependencies": {
+                    "brace-expansion": "^5.0.6"
+                }
+            }
         }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,8 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  minimatch@10.2.5>brace-expansion: ^5.0.6
+packageExtensionsChecksum: sha256-xx97ir72Z/Od9tONlIEsbEVKGUrhc6tGfUeweqcsMOk=
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch@10.2.5>brace-expansion: ^5.0.6
+
 importers:
 
   .:
@@ -1275,8 +1278,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5447,7 +5450,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7092,7 +7095,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
Fixes the moderate severity `brace-expansion` vulnerability (GHSA-jxxr-4gwj-5jf2).

**Problem:** `@vitest/coverage-v8` → `test-exclude` → `minimatch@10.2.5` → `brace-expansion@5.0.5` (vulnerable)

**Fix:** Added a parent-scoped pnpm override in `package.json` to pin the vulnerable path to a fixed version:

```json
"pnpm": {
  "overrides": {
    "minimatch@10.2.5>brace-expansion": "^5.0.6"
  }
}
```

This uses pnpm's `>` selective override syntax to target only `brace-expansion` when it's a dependency of `minimatch@10.2.5` — leaving `brace-expansion@1.1.14` (CJS, minimatch@3) and `brace-expansion@2.1.0` (CJS, minimatch@9) untouched.

**Why not a lockfile-only edit:** A raw lockfile edit can regress on regeneration. Declaring the override in `package.json` makes the fix durable.

**Verification:**
- ✅ `pnpm audit` — no known vulnerabilities
- ✅ `pnpm lint` — clean
- ✅ `pnpm test` — 190/190 tests pass
- ✅ `pnpm install` — lockfile valid
- ✅ Three distinct `brace-expansion` versions preserved (1.1.14, 2.1.0, 5.0.6)

Closes #86