### PR TITLE
fix(firefox): reliability bundle — storage mirror, context menu race, URL normalize, popup hydration

### DIFF
--- a/entrypoints/popup/App.css
+++ b/entrypoints/popup/App.css
@@ -13,7 +13,9 @@
     text-align: center;
     background-color: var(--mealie-black);
     color: var(--mealie-white);
-    overflow: hidden;
+    /* Popup content was taller than the panel on Firefox — overflow:hidden hid “Recent Activity”. */
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .logo {
@@ -67,6 +69,15 @@
     border: 1px solid #444;
     background-color: #2c2c2c;
     color: var(--mealie-white);
+}
+
+.connect-error-detail {
+    margin: 8px 0 0;
+    font-size: 12px;
+    line-height: 1.35;
+    color: #f0c4a8;
+    text-align: left;
+    word-break: break-word;
 }
 
 .recipe-mode-card {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -3,6 +3,11 @@ import './App.css';
 import { ChangeEvent, useEffect, useState } from 'react';
 
 import miniMealieLogo from '/mini-mealie.svg';
+import {
+    clearMealieCredentialsLocal,
+    mergeMealieCredentialsFromLocalIfNeeded,
+    mirrorMealieCredentialsToLocal,
+} from '@/utils/storage';
 import { isRecipeCreateMode, RecipeCreateMode } from '@/utils/types/storageTypes';
 
 /**
@@ -18,6 +23,18 @@ function toSafeHref(url: string): string {
     }
 }
 
+/** True if the field contains a URL with a hostname (not just `https://`). */
+function hasMealieHostInput(raw: string): boolean {
+    const trimmed = raw.trim();
+    if (!trimmed) return false;
+    try {
+        const parsed = new URL(trimmed);
+        return parsed.hostname.length > 0;
+    } catch {
+        return false;
+    }
+}
+
 function App() {
     const [protocol, setProtocol] = useState<Protocol>(Protocol.HTTPS);
     const [mealieServer, setMealieServer] = useState('');
@@ -30,26 +47,44 @@ function App() {
         RecipeCreateMode.URL,
     );
     const [error, setError] = useState(false);
+    const [connectErrorDetail, setConnectErrorDetail] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [importTags, setImportTags] = useState(true);
     const [importCategories, setImportCategories] = useState(true);
     const [openAfterImport, setOpenAfterImport] = useState(false);
 
     useEffect(() => {
-        chrome.storage.sync.get<StorageData>(
-            [...storageKeys],
-            ({
-                mealieServer,
-                mealieApiToken,
-                mealieUsername,
-                recipeCreateMode: storedRecipeCreateMode,
-                importTags: storedImportTags,
-                importCategories: storedImportCategories,
-                openAfterImport: storedOpenAfterImport,
-            }: StorageData) => {
-                if (mealieServer) setMealieServer(mealieServer);
-                setInputServer(protocol);
-                if (mealieApiToken) setMealieApiToken(mealieApiToken);
+        chrome.storage.sync.get<StorageData>([...storageKeys], (syncData: StorageData) => {
+            void chrome.runtime.lastError;
+
+            mergeMealieCredentialsFromLocalIfNeeded(syncData, (data: StorageData) => {
+                const {
+                    mealieServer: storedServer,
+                    mealieApiToken: storedToken,
+                    mealieUsername,
+                    recipeCreateMode: storedRecipeCreateMode,
+                    importTags: storedImportTags,
+                    importCategories: storedImportCategories,
+                    openAfterImport: storedOpenAfterImport,
+                } = data;
+
+                if (storedServer) {
+                    setMealieServer(storedServer);
+                    setInputServer(storedServer);
+                    setProtocol(
+                        storedServer.startsWith(`${Protocol.HTTP}`)
+                            ? Protocol.HTTP
+                            : Protocol.HTTPS,
+                    );
+                } else {
+                    setInputServer(Protocol.HTTPS);
+                }
+
+                if (storedToken) {
+                    setMealieApiToken(storedToken);
+                    setInputToken(storedToken);
+                }
+
                 if (mealieUsername) setUsername(mealieUsername);
                 if (isRecipeCreateMode(storedRecipeCreateMode)) {
                     setRecipeCreateMode(storedRecipeCreateMode);
@@ -67,9 +102,9 @@ function App() {
                         updateRecipeCreateMode(RecipeCreateMode.HTML);
                     }
                 });
-            },
-        );
-    }, [protocol]);
+            });
+        });
+    }, []);
 
     // Listen for storage changes (e.g., when context menu switches mode)
     useEffect(() => {
@@ -77,9 +112,23 @@ function App() {
             changes: { [key: string]: chrome.storage.StorageChange },
             areaName: chrome.storage.AreaName,
         ) => {
-            if (areaName !== 'sync') return;
+            if (areaName !== 'sync' && areaName !== 'local') return;
 
-            if (changes.recipeCreateMode?.newValue) {
+            if (changes.mealieServer?.newValue !== undefined) {
+                const next = changes.mealieServer.newValue as string | undefined;
+                setMealieServer(next ?? '');
+                setInputServer(next && next.length > 0 ? next : Protocol.HTTPS);
+            }
+            if (changes.mealieApiToken?.newValue !== undefined) {
+                const next = changes.mealieApiToken.newValue as string | undefined;
+                setMealieApiToken(next ?? '');
+                setInputToken(next ?? '');
+            }
+            if (changes.mealieUsername?.newValue !== undefined) {
+                setUsername(changes.mealieUsername.newValue as string | undefined);
+            }
+
+            if (areaName === 'sync' && changes.recipeCreateMode?.newValue) {
                 const newMode = changes.recipeCreateMode.newValue;
                 if (isRecipeCreateMode(newMode)) {
                     setRecipeCreateMode(newMode);
@@ -95,36 +144,69 @@ function App() {
     }, []);
 
     useEffect(() => {
-        const isDisabled = inputServer.trim() === '' || inputToken.trim() === '';
+        const isDisabled = !hasMealieHostInput(inputServer) || inputToken.trim() === '';
         setIsSaveDisabled(isDisabled);
     }, [inputServer, inputToken]);
 
-    const saveSettings = async () => {
-        if (inputServer.trim() === protocol || inputToken.trim() === '') return;
+    useEffect(() => {
+        setConnectErrorDetail(null);
+        setError(false);
+    }, [inputServer, inputToken]);
 
+    const saveSettings = async () => {
+        if (!hasMealieHostInput(inputServer) || inputToken.trim() === '') {
+            setConnectErrorDetail('Enter your full Mealie URL (with hostname) and API token.');
+            setError(true);
+            return;
+        }
+
+        setError(false);
+        setConnectErrorDetail(null);
         setLoading(true);
         setIsSaveDisabled(true);
-        const result = await getUser(inputServer, inputToken);
+        const result = await getUser(inputServer.trim(), inputToken.trim());
 
         if (!('username' in result)) {
+            setConnectErrorDetail(
+                'errorMessage' in result ? result.errorMessage : 'Connection failed.',
+            );
             setError(true);
             setLoading(false);
-            clearSettings();
+            setIsSaveDisabled(false);
             return;
         }
         chrome.storage.sync.set(
             {
-                mealieServer: inputServer,
-                mealieApiToken: inputToken,
+                mealieServer: inputServer.trim(),
+                mealieApiToken: inputToken.trim(),
                 mealieUsername: result.username,
                 ladderEnabled: false,
             },
             () => {
-                setMealieServer(inputServer);
-                setMealieApiToken(inputToken);
+                if (chrome.runtime.lastError) {
+                    console.error(
+                        '[Mini Mealie] storage.sync.set failed:',
+                        chrome.runtime.lastError.message,
+                    );
+                    setConnectErrorDetail(
+                        chrome.runtime.lastError.message ?? 'storage.sync.set failed',
+                    );
+                    setError(true);
+                    setLoading(false);
+                    setIsSaveDisabled(false);
+                    return;
+                }
+                mirrorMealieCredentialsToLocal({
+                    mealieServer: inputServer.trim(),
+                    mealieApiToken: inputToken.trim(),
+                    mealieUsername: result.username,
+                });
+                setMealieServer(inputServer.trim());
+                setMealieApiToken(inputToken.trim());
                 setUsername(result.username);
                 setLoading(false);
                 setIsSaveDisabled(false);
+                void checkStorageAndUpdateBadge();
             },
         );
     };
@@ -152,6 +234,7 @@ function App() {
     };
 
     const clearSettings = () => {
+        clearMealieCredentialsLocal();
         chrome.storage.sync.remove<StorageData>([...storageKeys], () => {
             setMealieServer('');
             setMealieApiToken('');
@@ -163,6 +246,8 @@ function App() {
             setImportTags(true);
             setImportCategories(true);
             setOpenAfterImport(false);
+            setError(false);
+            setConnectErrorDetail(null);
         });
     };
 
@@ -268,7 +353,16 @@ function App() {
                         <button onClick={saveSettings} disabled={isSaveDisabled}>
                             {loading ? 'Connecting...' : 'Connect Mealie'}
                         </button>
-                        {error && <h3>Invalid Server Settings</h3>}
+                        {error && (
+                            <>
+                                <h3>Could not connect</h3>
+                                <p className="connect-error-detail">
+                                    {connectErrorDetail ??
+                                        'Check your Mealie URL and API token, CORS/proxy settings, and Mealie logs.'}
+                                </p>
+                            </>
+                        )}
+                        <ActivityLog />
                     </>
                 ) : (
                     <>
@@ -353,6 +447,8 @@ function App() {
                             </label>
                         </div>
 
+                        <ActivityLog />
+
                         <button onClick={clearSettings}>Disconnect Server</button>
                     </>
                 )}
@@ -363,7 +459,6 @@ function App() {
                     Mealie
                 </a>
             </p>
-            <ActivityLog />
             <div className="buy-me-a-coffee-container">
                 <BuyMeACoffeeButton />
             </div>

--- a/utils/contextMenu.ts
+++ b/utils/contextMenu.ts
@@ -1,4 +1,5 @@
 import type { DuplicateDetectionResult } from './storage';
+import type { RecipeSummary } from './types/apiTypes';
 
 export const MINI_MEALIE_PARENT_ID = 'miniMealieParent';
 export const RUN_CREATE_RECIPE_MENU_ID = 'runCreateRecipe';
@@ -6,6 +7,15 @@ export const DUPLICATE_DETECTION_PARENT_ID = 'duplicateDetection';
 export const DUPLICATE_URL_MENU_ID = 'viewDuplicateUrl';
 export const DUPLICATE_NAME_MENU_ID = 'viewDuplicatesByName';
 export const SWITCH_TO_HTML_MODE_ID = 'switchToHtmlMode';
+
+/**
+ * Recipe sites are mostly links/images; `page` alone only fires on blank page chrome,
+ * so menus never appear for typical right-clicks.
+ */
+export const RECIPE_MENU_CONTEXTS: [
+    `${chrome.contextMenus.ContextType}`,
+    ...`${chrome.contextMenus.ContextType}`[],
+] = ['page', 'frame', 'link', 'selection', 'image'];
 
 // Keep track of child menu IDs for cleanup
 const childMenuIds: string[] = [];
@@ -28,7 +38,7 @@ export const addContextMenu = (title: string, enabled = true) => {
                 id: RUN_CREATE_RECIPE_MENU_ID,
                 title,
                 enabled,
-                contexts: ['page'],
+                contexts: RECIPE_MENU_CONTEXTS,
             });
         });
         return;
@@ -37,42 +47,41 @@ export const addContextMenu = (title: string, enabled = true) => {
     if (!canUpdate || !canCreate) return;
 
     chrome.contextMenus.update(RUN_CREATE_RECIPE_MENU_ID, { title, enabled }, () => {
-        if (!chrome.runtime.lastError) return;
+        if (!chrome.runtime?.lastError) return;
         chrome.contextMenus.create(
             {
                 id: RUN_CREATE_RECIPE_MENU_ID,
                 title,
                 enabled,
-                contexts: ['page'],
+                contexts: RECIPE_MENU_CONTEXTS,
             },
             () => {
                 // Ignore "already exists" and other transient errors.
-                void chrome.runtime.lastError;
+                void chrome.runtime?.lastError;
             },
         );
     });
 };
 
 export const removeContextMenu = () => {
-    const canRemove = typeof chrome.contextMenus.remove === 'function';
     const canRemoveAll = typeof chrome.contextMenus.removeAll === 'function';
 
-    // Test environments sometimes only mock removeAll.
-    if (!canRemove && canRemoveAll) {
-        void chrome.contextMenus.removeAll();
+    // Prefer removeAll: parallel remove()+create races Firefox (duplicate id errors are swallowed).
+    if (canRemoveAll) {
+        childMenuIds.length = 0;
+        chrome.contextMenus.removeAll(() => void chrome.runtime?.lastError);
         return;
     }
 
+    const canRemove = typeof chrome.contextMenus.remove === 'function';
     if (!canRemove) return;
 
-    // Remove parent (which removes all children)
     chrome.contextMenus.remove(MINI_MEALIE_PARENT_ID, () => {
-        void chrome.runtime.lastError;
+        void chrome.runtime?.lastError;
     });
 
-    // Also remove individual items in case they exist
     chrome.contextMenus.remove(RUN_CREATE_RECIPE_MENU_ID, () => {
-        void chrome.runtime.lastError;
+        void chrome.runtime?.lastError;
     });
 };
 
@@ -84,16 +93,16 @@ export const removeAllDuplicateMenus = () => {
     if (!canRemove) return;
 
     chrome.contextMenus.remove(DUPLICATE_URL_MENU_ID, () => {
-        void chrome.runtime.lastError;
+        void chrome.runtime?.lastError;
     });
     chrome.contextMenus.remove(DUPLICATE_NAME_MENU_ID, () => {
-        void chrome.runtime.lastError;
+        void chrome.runtime?.lastError;
     });
 
     // Remove all child menu items
     for (const childId of childMenuIds) {
         chrome.contextMenus.remove(childId, () => {
-            void chrome.runtime.lastError;
+            void chrome.runtime?.lastError;
         });
     }
     childMenuIds.length = 0; // Clear the array
@@ -108,47 +117,51 @@ export const removeAllDuplicateMenus = () => {
  * @param duplicateInfo - Information about detected duplicates
  * @param isErrorSuggestion - Whether the create title is an error suggesting mode switch
  */
-export const updateContextMenu = (
-    createTitle: string,
-    createEnabled: boolean,
-    duplicateInfo: DuplicateInfo,
-    isErrorSuggestion = false,
-) => {
-    // Remove all menus first to ensure correct ordering
-    removeContextMenu();
-    removeAllDuplicateMenus();
+function createNameMatchChildrenFromIterator(iter: Iterator<RecipeSummary>): void {
+    const step = iter.next();
+    if (step.done || !step.value) return;
 
-    const canCreate = typeof chrome.contextMenus.create === 'function';
-    if (!canCreate) return;
-
-    // 1. Create parent "Mini Mealie" menu
+    const match = step.value;
+    const childId = `${DUPLICATE_NAME_MENU_ID}:${match.slug}`;
+    childMenuIds.push(childId);
     chrome.contextMenus.create(
         {
-            id: MINI_MEALIE_PARENT_ID,
-            title: 'Mini Mealie',
-            contexts: ['page'],
+            id: childId,
+            parentId: DUPLICATE_NAME_MENU_ID,
+            title: match.name,
+            enabled: true,
+            contexts: RECIPE_MENU_CONTEXTS,
         },
         () => {
-            void chrome.runtime.lastError;
+            void chrome.runtime?.lastError;
+            createNameMatchChildrenFromIterator(iter);
         },
     );
+}
 
-    // 2. Create the main "Create Recipe" menu as child of parent
-    const menuId = isErrorSuggestion ? SWITCH_TO_HTML_MODE_ID : RUN_CREATE_RECIPE_MENU_ID;
+function createNameMatchParentMenu(duplicateInfo: DuplicateInfo): void {
+    if (!duplicateInfo.nameMatches || duplicateInfo.nameMatches.length === 0) return;
+
+    const matches = duplicateInfo.nameMatches;
+    const recipeWord = matches.length === 1 ? 'recipe' : 'recipes';
+
     chrome.contextMenus.create(
         {
-            id: menuId,
+            id: DUPLICATE_NAME_MENU_ID,
             parentId: MINI_MEALIE_PARENT_ID,
-            title: createTitle,
-            enabled: createEnabled,
-            contexts: ['page'],
+            title: `🔍 Found ${matches.length} similar ${recipeWord}`,
+            enabled: true,
+            contexts: RECIPE_MENU_CONTEXTS,
         },
         () => {
-            void chrome.runtime.lastError;
+            void chrome.runtime?.lastError;
+            createNameMatchChildrenFromIterator(matches[Symbol.iterator]());
         },
     );
+}
 
-    // 3. Create "Already exists" menu if URL match found (sibling of create option)
+/** Chain sibling menus after the primary action so parents exist before children (Firefox-sensitive). */
+function createDuplicateSiblingMenus(duplicateInfo: DuplicateInfo): void {
     if (duplicateInfo.urlMatch) {
         chrome.contextMenus.create(
             {
@@ -156,47 +169,57 @@ export const updateContextMenu = (
                 parentId: MINI_MEALIE_PARENT_ID,
                 title: `⚠️ Already exists: "${duplicateInfo.urlMatch.name}"`,
                 enabled: true,
-                contexts: ['page'],
+                contexts: RECIPE_MENU_CONTEXTS,
             },
             () => {
-                void chrome.runtime.lastError;
+                void chrome.runtime?.lastError;
+                createNameMatchParentMenu(duplicateInfo);
             },
         );
+        return;
     }
 
-    // 4. Create "Found X similar recipes" menu if name matches found (sibling of create option)
-    if (duplicateInfo.nameMatches && duplicateInfo.nameMatches.length > 0) {
-        const matches = duplicateInfo.nameMatches;
-        const recipeWord = matches.length === 1 ? 'recipe' : 'recipes';
+    createNameMatchParentMenu(duplicateInfo);
+}
+
+export const updateContextMenu = (
+    createTitle: string,
+    createEnabled: boolean,
+    duplicateInfo: DuplicateInfo,
+    isErrorSuggestion = false,
+) => {
+    const canCreate = typeof chrome.contextMenus.create === 'function';
+    const canRemoveAll = typeof chrome.contextMenus.removeAll === 'function';
+    if (!canCreate || !canRemoveAll) return;
+
+    const menuId = isErrorSuggestion ? SWITCH_TO_HTML_MODE_ID : RUN_CREATE_RECIPE_MENU_ID;
+
+    chrome.contextMenus.removeAll(() => {
+        void chrome.runtime?.lastError;
+        childMenuIds.length = 0;
+
         chrome.contextMenus.create(
             {
-                id: DUPLICATE_NAME_MENU_ID,
-                parentId: MINI_MEALIE_PARENT_ID,
-                title: `🔍 Found ${matches.length} similar ${recipeWord}`,
-                enabled: true,
-                contexts: ['page'],
+                id: MINI_MEALIE_PARENT_ID,
+                title: 'Mini Mealie',
+                contexts: RECIPE_MENU_CONTEXTS,
             },
             () => {
-                void chrome.runtime.lastError;
+                void chrome.runtime?.lastError;
+                chrome.contextMenus.create(
+                    {
+                        id: menuId,
+                        parentId: MINI_MEALIE_PARENT_ID,
+                        title: createTitle,
+                        enabled: createEnabled,
+                        contexts: RECIPE_MENU_CONTEXTS,
+                    },
+                    () => {
+                        void chrome.runtime?.lastError;
+                        createDuplicateSiblingMenus(duplicateInfo);
+                    },
+                );
             },
         );
-
-        // Create child menu items for each match (grandchildren of parent)
-        for (const match of matches) {
-            const childId = `${DUPLICATE_NAME_MENU_ID}:${match.slug}`;
-            childMenuIds.push(childId);
-            chrome.contextMenus.create(
-                {
-                    id: childId,
-                    parentId: DUPLICATE_NAME_MENU_ID,
-                    title: match.name,
-                    enabled: true,
-                    contexts: ['page'],
-                },
-                () => {
-                    void chrome.runtime.lastError;
-                },
-            );
-        }
-    }
+    });
 };

--- a/utils/devInit.ts
+++ b/utils/devInit.ts
@@ -1,3 +1,27 @@
+import { mirrorMealieCredentialsToLocal } from './storage';
+
+function persistDevCredentials(data: {
+    mealieServer: string;
+    mealieApiToken: string;
+    mealieUsername?: string;
+}): Promise<void> {
+    return new Promise((resolve) => {
+        chrome.storage.sync.set(
+            {
+                mealieServer: data.mealieServer,
+                mealieApiToken: data.mealieApiToken,
+                ...(data.mealieUsername !== undefined
+                    ? { mealieUsername: data.mealieUsername }
+                    : {}),
+            },
+            () => {
+                mirrorMealieCredentialsToLocal(data);
+                resolve();
+            },
+        );
+    });
+}
+
 /**
  * Pre-populate extension storage from environment variables during development.
  * Only runs in dev mode when env vars are present.
@@ -48,7 +72,7 @@ export async function initDevEnvironment(): Promise<void> {
         const userResult = await getUser(server, token);
 
         if ('username' in userResult) {
-            await chrome.storage.sync.set({
+            await persistDevCredentials({
                 mealieServer: server,
                 mealieApiToken: token,
                 mealieUsername: userResult.username,
@@ -58,17 +82,12 @@ export async function initDevEnvironment(): Promise<void> {
             });
         } else {
             console.warn('[DevInit] Failed to fetch user profile:', userResult.errorMessage);
-            const storageData: Record<string, string> = {
+            const wroteUsername = Boolean(username);
+            await persistDevCredentials({
                 mealieServer: server,
                 mealieApiToken: token,
-            };
-
-            if (username) {
-                storageData.mealieUsername = username;
-            }
-
-            const wroteUsername = Boolean(username);
-            await chrome.storage.sync.set(storageData);
+                ...(username ? { mealieUsername: username } : {}),
+            });
             console.log(
                 wroteUsername
                     ? '[DevInit] Storage pre-populated (with unverified username from .env.local)'

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -2,6 +2,14 @@ import normalizeUrlLib from 'normalize-url';
 
 export type CreateRecipeResult = { slug: string } | 'failure';
 
+/** `/api/recipes` duplicate lookups had no timeout — a hung Mealie blocked URL-mode context menus. */
+const DUPLICATE_DETECT_FETCH_TIMEOUT_MS = 12_000;
+
+/** Trim and strip trailing slashes so `${base}/api/...` never becomes `//api/...`. */
+export function normalizeMealieServerBaseUrl(serverUrl: string): string {
+    return serverUrl.trim().replace(/\/+$/, '');
+}
+
 /**
  * Normalize a URL for duplicate detection matching.
  * Removes tracking parameters, www prefix, trailing slashes, and fragments.
@@ -198,13 +206,16 @@ export const getUser = async (
         action: 'getUser',
         phase: 'start',
         message: 'Fetching user profile',
-        data: { server: sanitizeUrl(url) },
+        data: { server: sanitizeUrl(normalizeMealieServerBaseUrl(url)) },
     });
 
     try {
-        const res = await fetch(`${url}/api/users/self`, {
+        const base = normalizeMealieServerBaseUrl(url);
+        const authToken = token.trim();
+
+        const res = await fetch(`${base}/api/users/self`, {
             headers: {
-                Authorization: `Bearer ${token}`,
+                Authorization: `Bearer ${authToken}`,
                 'Content-Type': 'application/json',
             },
         });
@@ -213,16 +224,27 @@ export const getUser = async (
         }
         const user = await res.json();
 
+        if (
+            !user ||
+            typeof user !== 'object' ||
+            typeof (user as Record<string, unknown>).username !== 'string'
+        ) {
+            return {
+                errorMessage:
+                    'Mealie response did not include a username — check your server URL and Mealie version.',
+            };
+        }
+
         await logEvent({
             level: 'info',
             feature: 'auth',
             action: 'getUser',
             phase: 'success',
             message: 'User profile fetched',
-            data: { server: sanitizeUrl(url), username: user.username },
+            data: { server: sanitizeUrl(base), username: (user as User).username },
         });
 
-        return user;
+        return user as User;
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
 
@@ -232,7 +254,7 @@ export const getUser = async (
             action: 'getUser',
             phase: 'failure',
             message: `Failed to fetch user: ${errorMessage}`,
-            data: { server: sanitizeUrl(url) },
+            data: { server: sanitizeUrl(normalizeMealieServerBaseUrl(url)) },
         });
 
         if (error instanceof Error) {
@@ -269,11 +291,13 @@ export const testScrapeUrlDetailed = async (
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-        const res = (await fetch(`${server}/api/recipes/test-scrape-url`, {
+        const mealieBase = normalizeMealieServerBaseUrl(server);
+
+        const res = (await fetch(`${mealieBase}/api/recipes/test-scrape-url`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                Authorization: `Bearer ${token}`,
+                Authorization: `Bearer ${token.trim()}`,
             },
             body: JSON.stringify({ url }),
             signal: controller.signal,
@@ -340,12 +364,20 @@ export async function findRecipeByURL(
         apiUrl.searchParams.set('orderBy', 'dateUpdated');
         apiUrl.searchParams.set('orderDirection', 'desc');
 
-        const res = (await fetch(apiUrl.href, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-                'Content-Type': 'application/json',
-            },
-        })) as FetchLikeResponse;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), DUPLICATE_DETECT_FETCH_TIMEOUT_MS);
+        let res: FetchLikeResponse;
+        try {
+            res = (await fetch(apiUrl.href, {
+                headers: {
+                    Authorization: `Bearer ${token.trim()}`,
+                    'Content-Type': 'application/json',
+                },
+                signal: controller.signal,
+            })) as FetchLikeResponse;
+        } finally {
+            clearTimeout(timeoutId);
+        }
 
         if (!res.ok) {
             await logEvent({
@@ -427,12 +459,20 @@ export async function searchRecipesByName(
         apiUrl.searchParams.set('search', name);
         apiUrl.searchParams.set('perPage', '5');
 
-        const res = (await fetch(apiUrl.href, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-                'Content-Type': 'application/json',
-            },
-        })) as FetchLikeResponse;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), DUPLICATE_DETECT_FETCH_TIMEOUT_MS);
+        let res: FetchLikeResponse;
+        try {
+            res = (await fetch(apiUrl.href, {
+                headers: {
+                    Authorization: `Bearer ${token.trim()}`,
+                    'Content-Type': 'application/json',
+                },
+                signal: controller.signal,
+            })) as FetchLikeResponse;
+        } finally {
+            clearTimeout(timeoutId);
+        }
 
         if (!res.ok) {
             await logEvent({

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,3 +1,5 @@
+import { logEvent } from './logging';
+
 const DETECTION_CACHE_TTL_MS = 30_000;
 const DETECTION_CACHE_MAX_SIZE = 100;
 
@@ -9,6 +11,7 @@ export const RESTRICTED_PROTOCOLS = [
     'chrome:',
     'chrome-extension:',
     'chrome-untrusted:',
+    'moz-extension:',
     'about:',
     'data:',
     'file:',
@@ -52,7 +55,7 @@ export function invalidateDetectionCacheForUrl(url: string) {
 
 /**
  * Check if a URL uses a restricted protocol that prevents script injection.
- * Returns true for chrome://, chrome-extension://, about:, data:, file:, etc.
+ * Returns true for chrome://, chrome-extension://, moz-extension://, about:, data:, file:, etc.
  * @param url - The URL to check
  * @returns true if the URL is restricted, false otherwise
  */
@@ -73,7 +76,6 @@ export function isRestrictedUrl(url: string): boolean {
 function disableAllMenus(): void {
     showBadge('');
     removeContextMenu();
-    removeAllDuplicateMenus();
 }
 
 /**
@@ -280,6 +282,12 @@ async function processFreshDetection(
         if (result.recipeName) {
             cacheEntry.recipeName = result.recipeName;
         }
+        // Show menu immediately after scrape — duplicate checks use unbounded Mealie fetches and
+        // previously blocked updateContextMenu until they finished (often forever if Mealie hung).
+        if (checkId === lastCheckId) {
+            const interimTitle = getTitleForOutcome(result.outcome, cacheEntry.status, isUrlMode);
+            updateContextMenu(interimTitle, true, {}, false);
+        }
         // Check for duplicates
         const duplicateDetection = await checkForDuplicates(
             url,
@@ -361,78 +369,237 @@ async function logDetectionResult(
     }
 }
 
-export const checkStorageAndUpdateBadge = async () => {
-    const checkId = ++lastCheckId;
+const MEALIE_CREDENTIAL_LOCAL_KEYS = ['mealieServer', 'mealieApiToken', 'mealieUsername'] as const;
 
-    chrome.storage.sync.get(
-        [...storageKeys],
-        async ({ mealieServer, mealieApiToken, recipeCreateMode }: StorageData) => {
-            if (checkId !== lastCheckId) return;
-
-            if (!mealieServer || !mealieApiToken) {
-                showBadge('❌');
-                removeContextMenu();
-                return;
-            }
-
-            const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-            if (checkId !== lastCheckId) return;
-
-            const { url } = tab ?? {};
-            const mode = isRecipeCreateMode(recipeCreateMode)
-                ? recipeCreateMode
-                : RecipeCreateMode.URL;
-            const isUrlMode = mode === RecipeCreateMode.URL;
-
-            // Skip internal browser and extension pages (applies to both URL and HTML modes)
-            // Script injection fails on these pages due to browser security restrictions
-            if (url && isRestrictedUrl(url)) {
-                disableAllMenus();
-                return;
-            }
-
-            // In HTML mode, always show static title and enable
-            // No detection or duplicate checking needed
-            if (!isUrlMode) {
-                updateContextMenu('Create Recipe from HTML', true, {}, false);
-                return;
-            }
-
-            // From here on, we're in URL mode only
-            let title = 'No Recipe - Switch to HTML Mode';
-            const enabled = true; // Always enabled
-            let isErrorSuggestion = true; // Default to error state
-            let duplicateInfo: DuplicateDetectionResult = {};
-
-            if (url) {
-                pruneDetectionCache();
-
-                const cached = detectionCache.get(url);
-                const now = Date.now();
-
-                let detectionResult: DetectionProcessingResult | null = null;
-
-                if (cached && now - cached.checkedAt < DETECTION_CACHE_TTL_MS) {
-                    detectionResult = processCachedDetection(cached, isUrlMode);
-                } else {
-                    detectionResult = await processFreshDetection(
-                        url,
-                        now,
-                        checkId,
-                        mealieServer,
-                        mealieApiToken,
-                        isUrlMode,
-                    );
-                    if (!detectionResult) return; // Cancelled
-                }
-
-                title = detectionResult.title;
-                isErrorSuggestion = detectionResult.isErrorSuggestion;
-                duplicateInfo = detectionResult.duplicateInfo;
-            }
-
-            // Always use updateContextMenu with duplicate info
-            updateContextMenu(title, enabled, duplicateInfo, isErrorSuggestion);
+/** Persist Mealie credentials to storage.local (Firefox/temporary profiles can lose sync-only writes). */
+export function mirrorMealieCredentialsToLocal(creds: {
+    mealieServer: string;
+    mealieApiToken: string;
+    mealieUsername?: string;
+}): void {
+    chrome.storage.local.set(
+        {
+            mealieServer: creds.mealieServer,
+            mealieApiToken: creds.mealieApiToken,
+            mealieUsername: creds.mealieUsername ?? '',
         },
+        () => void chrome.runtime.lastError,
     );
-};
+}
+
+export function clearMealieCredentialsLocal(): void {
+    chrome.storage.local.remove(
+        [...MEALIE_CREDENTIAL_LOCAL_KEYS],
+        () => void chrome.runtime.lastError,
+    );
+}
+
+/**
+ * When sync is missing credentials, merge from storage.local and back-fill sync.
+ * Used by popup hydration and badge/menu refresh (Firefox-friendly).
+ */
+export function mergeMealieCredentialsFromLocalIfNeeded(
+    syncData: StorageData,
+    onMerged: (data: StorageData) => void,
+): void {
+    if (syncData.mealieServer && syncData.mealieApiToken) {
+        onMerged(syncData);
+        return;
+    }
+
+    chrome.storage.local.get([...MEALIE_CREDENTIAL_LOCAL_KEYS], (local: Partial<StorageData>) => {
+        void chrome.runtime.lastError;
+
+        const merged: StorageData = {
+            ...syncData,
+            mealieServer: syncData.mealieServer ?? local.mealieServer,
+            mealieApiToken: syncData.mealieApiToken ?? local.mealieApiToken,
+            mealieUsername: syncData.mealieUsername ?? local.mealieUsername,
+        };
+
+        if (
+            merged.mealieServer &&
+            merged.mealieApiToken &&
+            (!syncData.mealieServer || !syncData.mealieApiToken)
+        ) {
+            chrome.storage.sync.set(
+                {
+                    mealieServer: merged.mealieServer,
+                    mealieApiToken: merged.mealieApiToken,
+                    mealieUsername: merged.mealieUsername,
+                },
+                () => void chrome.runtime.lastError,
+            );
+        }
+
+        onMerged(merged);
+    });
+}
+
+/** Always persisted to Activity Logs — root-cause signal when only `auth/getUser` appears from the popup. */
+const BADGE_MENU_LOG_SCHEMA = 2;
+
+function recordBadgeMenuRefresh(summary: Record<string, unknown>): void {
+    const outcome = typeof summary.outcome === 'string' ? summary.outcome : 'badgeMenuRefresh';
+    void Promise.resolve(
+        logEvent({
+            level: 'info',
+            feature: 'recipe-detect',
+            action: 'badgeMenuRefresh',
+            phase: 'success',
+            message: outcome,
+            data: { ...summary, schema: BADGE_MENU_LOG_SCHEMA },
+        }),
+    ).catch(() => undefined);
+}
+
+async function runStorageCheckAfterMerge(checkId: number, data: StorageData): Promise<void> {
+    const { mealieServer, mealieApiToken, recipeCreateMode } = data;
+    if (checkId !== lastCheckId) return;
+
+    if (!mealieServer || !mealieApiToken) {
+        showBadge('❌');
+        removeContextMenu();
+        recordBadgeMenuRefresh({
+            outcome: 'skipped_no_credentials',
+            srv: Boolean(mealieServer),
+            tok: Boolean(mealieApiToken),
+        });
+        return;
+    }
+
+    let tabsResult: chrome.tabs.Tab[];
+    try {
+        tabsResult = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    } catch (err) {
+        recordBadgeMenuRefresh({
+            outcome: 'tabs_query_rejected',
+            error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+    }
+    if (checkId !== lastCheckId) return;
+
+    const [tab] = tabsResult;
+    const { url } = tab ?? {};
+    const mode = isRecipeCreateMode(recipeCreateMode) ? recipeCreateMode : RecipeCreateMode.URL;
+    const isUrlMode = mode === RecipeCreateMode.URL;
+
+    // Skip internal browser and extension pages (applies to both URL and HTML modes)
+    // Script injection fails on these pages due to browser security restrictions
+    if (url && isRestrictedUrl(url)) {
+        disableAllMenus();
+        recordBadgeMenuRefresh({
+            outcome: 'skipped_restricted_tab',
+            url: sanitizeUrl(url),
+            recipeCreateMode: mode,
+            tabsReturned: tabsResult.length,
+        });
+        return;
+    }
+
+    // In HTML mode, always show static title and enable
+    // No detection or duplicate checking needed
+    if (!isUrlMode) {
+        updateContextMenu('Create Recipe from HTML', true, {}, false);
+        recordBadgeMenuRefresh({
+            outcome: 'html_mode_static_menu',
+            tabsReturned: tabsResult.length,
+            activeTabId: tab?.id,
+            hadTabUrl: Boolean(url),
+        });
+        return;
+    }
+
+    // From here on, we're in URL mode only
+    let title = 'No Recipe - Switch to HTML Mode';
+    const enabled = true; // Always enabled
+    let isErrorSuggestion = true; // Default to error state
+    let duplicateInfo: DuplicateDetectionResult = {};
+
+    if (url) {
+        pruneDetectionCache();
+
+        const cached = detectionCache.get(url);
+        const now = Date.now();
+
+        let detectionResult: DetectionProcessingResult | null = null;
+
+        if (cached && now - cached.checkedAt < DETECTION_CACHE_TTL_MS) {
+            detectionResult = processCachedDetection(cached, isUrlMode);
+        } else {
+            detectionResult = await processFreshDetection(
+                url,
+                now,
+                checkId,
+                mealieServer,
+                mealieApiToken,
+                isUrlMode,
+            );
+            if (!detectionResult) {
+                recordBadgeMenuRefresh({
+                    outcome: 'skipped_detection_superseded',
+                    hadTabUrl: Boolean(url),
+                    tabUrlHint: url ? sanitizeUrl(url) : undefined,
+                    tabsReturned: tabsResult.length,
+                });
+                return;
+            }
+        }
+
+        title = detectionResult.title;
+        isErrorSuggestion = detectionResult.isErrorSuggestion;
+        duplicateInfo = detectionResult.duplicateInfo;
+    }
+
+    // Always use updateContextMenu with duplicate info
+    updateContextMenu(title, enabled, duplicateInfo, isErrorSuggestion);
+    recordBadgeMenuRefresh({
+        outcome: 'menu_updated',
+        recipeCreateMode: RecipeCreateMode.URL,
+        menuTitle: title,
+        hadTabUrl: Boolean(url),
+        tabUrlHint: url ? sanitizeUrl(url) : undefined,
+        tabsReturned: tabsResult.length,
+        activeTabId: tab?.id,
+    });
+}
+
+/**
+ * Overlapping badge/menu refreshes each incremented `lastCheckId` before earlier scrapes finished,
+ * so `processFreshDetection` constantly returned null (cancelled) and the context menu never appeared.
+ * Serialize refreshes so only one check id is “live” during Mealie I/O.
+ */
+let refreshTail: Promise<void> = Promise.resolve();
+
+/** Reset serialized refresh state between Vitest cases (module singleton). */
+export function resetBadgeMenuRefreshQueueForTests(): void {
+    refreshTail = Promise.resolve();
+}
+
+async function runQueuedStorageCheck(): Promise<void> {
+    const checkId = ++lastCheckId;
+    await new Promise<void>((resolve) => {
+        chrome.storage.sync.get([...storageKeys], (syncData: StorageData) => {
+            void chrome.runtime?.lastError;
+            mergeMealieCredentialsFromLocalIfNeeded(syncData, (merged) => {
+                recordBadgeMenuRefresh({
+                    outcome: 'pipeline_job',
+                    step: 'merged_credentials',
+                    checkId,
+                    srv: Boolean(merged.mealieServer),
+                    tok: Boolean(merged.mealieApiToken),
+                    mode: merged.recipeCreateMode ?? null,
+                });
+                void runStorageCheckAfterMerge(checkId, merged).finally(() => resolve());
+            });
+        });
+    });
+}
+
+/** Queue a badge/context-menu refresh; resolves when this queued hop completes. */
+export function checkStorageAndUpdateBadge(): Promise<void> {
+    const job = refreshTail.then(() => runQueuedStorageCheck());
+    refreshTail = job.catch(() => undefined);
+    return job;
+}

--- a/utils/tests/contextMenu.test.ts
+++ b/utils/tests/contextMenu.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     addContextMenu,
+    RECIPE_MENU_CONTEXTS,
     removeAllDuplicateMenus,
     removeContextMenu,
     updateContextMenu,
@@ -14,6 +15,7 @@ beforeEach(() => {
             removeAll: vi.fn((callback) => callback && callback()),
             create: vi.fn(),
         },
+        runtime: { lastError: undefined },
     } as unknown as typeof chrome;
 });
 
@@ -26,7 +28,7 @@ describe('Context Menu Utility', () => {
             id: 'runCreateRecipe',
             title: 'No Recipe Detected - Attempt to Add Recipe',
             enabled: true,
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
     });
 
@@ -83,26 +85,17 @@ describe('Context Menu Utility (update/remove path)', () => {
                 id: 'runCreateRecipe',
                 title: 'No Recipe Detected - Attempt to Add Recipe',
                 enabled: true,
-                contexts: ['page'],
+                contexts: RECIPE_MENU_CONTEXTS,
             },
             expect.any(Function),
         );
     });
 
-    it('should remove the parent context menu and child items when supported', () => {
+    it('should clear all extension context menus when removeAll is available', () => {
         removeContextMenu();
 
-        // Should remove parent (which cascades to children)
-        expect(chrome.contextMenus.remove).toHaveBeenCalledWith(
-            'miniMealieParent',
-            expect.any(Function),
-        );
-
-        // Should also explicitly remove create menu item
-        expect(chrome.contextMenus.remove).toHaveBeenCalledWith(
-            'runCreateRecipe',
-            expect.any(Function),
-        );
+        expect(chrome.contextMenus.removeAll).toHaveBeenCalled();
+        expect(chrome.contextMenus.remove).not.toHaveBeenCalled();
     });
 });
 
@@ -124,6 +117,8 @@ describe('updateContextMenu', () => {
     it('should create main menu and no duplicate menus when type is none', () => {
         updateContextMenu('Create Recipe from URL', true, {}, false);
 
+        expect(chrome.contextMenus.removeAll).toHaveBeenCalled();
+
         // Should create parent menu + create menu (no duplicates)
         const createCalls = (chrome.contextMenus.create as ReturnType<typeof vi.fn>).mock.calls;
         expect(createCalls.length).toBe(2);
@@ -132,7 +127,7 @@ describe('updateContextMenu', () => {
         expect(createCalls[0][0]).toEqual({
             id: 'miniMealieParent',
             title: 'Mini Mealie',
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
 
         // Second should be create menu as child
@@ -141,18 +136,10 @@ describe('updateContextMenu', () => {
             parentId: 'miniMealieParent',
             title: 'Create Recipe from URL',
             enabled: true,
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
 
-        // Duplicate removal should be called
-        expect(chrome.contextMenus.remove).toHaveBeenCalledWith(
-            'viewDuplicateUrl',
-            expect.any(Function),
-        );
-        expect(chrome.contextMenus.remove).toHaveBeenCalledWith(
-            'viewDuplicatesByName',
-            expect.any(Function),
-        );
+        expect(chrome.contextMenus.remove).not.toHaveBeenCalled();
     });
 
     it('should create URL duplicate warning menu when exact match found', () => {
@@ -173,7 +160,7 @@ describe('updateContextMenu', () => {
         expect(createCalls[0][0]).toEqual({
             id: 'miniMealieParent',
             title: 'Mini Mealie',
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
 
         // Second should be create menu
@@ -182,7 +169,7 @@ describe('updateContextMenu', () => {
             parentId: 'miniMealieParent',
             title: 'Create Recipe from URL',
             enabled: true,
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
 
         // Third should be duplicate URL menu (sibling of create)
@@ -191,7 +178,7 @@ describe('updateContextMenu', () => {
             parentId: 'miniMealieParent',
             title: '⚠️ Already exists: "Chicken Carbonara"',
             enabled: true,
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
     });
 
@@ -217,7 +204,7 @@ describe('updateContextMenu', () => {
         expect(createCalls[0][0]).toEqual({
             id: 'miniMealieParent',
             title: 'Mini Mealie',
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
 
         // Second should be create menu
@@ -226,7 +213,7 @@ describe('updateContextMenu', () => {
             parentId: 'miniMealieParent',
             title: 'Create Recipe from URL',
             enabled: true,
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
 
         // Third should be duplicate name menu (plural, sibling of create)
@@ -235,7 +222,7 @@ describe('updateContextMenu', () => {
             parentId: 'miniMealieParent',
             title: '🔍 Found 2 similar recipes',
             enabled: true,
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
     });
 
@@ -262,7 +249,7 @@ describe('updateContextMenu', () => {
             parentId: 'miniMealieParent',
             title: '🔍 Found 1 similar recipe',
             enabled: true,
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
     });
 
@@ -313,7 +300,7 @@ describe('updateContextMenu', () => {
             parentId: 'miniMealieParent',
             title: 'No Recipe - Switch to HTML Mode',
             enabled: true, // Always enabled to allow clicking
-            contexts: ['page'],
+            contexts: RECIPE_MENU_CONTEXTS,
         });
     });
 });

--- a/utils/tests/network.test.ts
+++ b/utils/tests/network.test.ts
@@ -782,6 +782,52 @@ describe('getUser', () => {
         );
     });
 
+    it('should strip trailing slashes from server URL before calling API', async () => {
+        global.fetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockUser,
+        });
+
+        await getUser('https://example.com/', mockToken);
+
+        expect(fetch).toHaveBeenCalledWith(
+            'https://example.com/api/users/self',
+            expect.any(Object),
+        );
+    });
+
+    it('should trim token whitespace for Authorization header', async () => {
+        global.fetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockUser,
+        });
+
+        await getUser(mockUrl, `  ${mockToken}  `);
+
+        expect(fetch).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Authorization: `Bearer ${mockToken}`,
+                }),
+            }),
+        );
+    });
+
+    it('should return error when JSON profile has no username', async () => {
+        global.fetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ email: 'x@y.z' }),
+        });
+
+        const result = await getUser(mockUrl, mockToken);
+
+        expect(result).toEqual({
+            errorMessage:
+                'Mealie response did not include a username — check your server URL and Mealie version.',
+        });
+    });
+
     it('should return an error message if the API returns a non-OK status', async () => {
         global.fetch = vi.fn().mockResolvedValueOnce({
             ok: false,

--- a/utils/tests/storage.test.ts
+++ b/utils/tests/storage.test.ts
@@ -4,7 +4,11 @@ import { WxtVitest } from 'wxt/testing';
 import { clearBadge, showBadge } from '../badge';
 import { removeContextMenu, updateContextMenu } from '../contextMenu';
 import { testScrapeUrlDetailed } from '../network';
-import { checkStorageAndUpdateBadge, clearDetectionCache } from '../storage';
+import {
+    checkStorageAndUpdateBadge,
+    clearDetectionCache,
+    resetBadgeMenuRefreshQueueForTests,
+} from '../storage';
 
 void WxtVitest();
 
@@ -46,6 +50,13 @@ describe('checkStorageAndUpdateBadge', () => {
         fakeBrowser.reset();
         vi.clearAllMocks();
         clearDetectionCache();
+        resetBadgeMenuRefreshQueueForTests();
+        // Incomplete sync credentials merge from local; default empty so tests stay deterministic.
+        vi.spyOn(chrome.storage.local, 'get').mockImplementation(
+            (_keys, callback: (items: Record<string, string | undefined>) => void) => {
+                callback({});
+            },
+        );
     });
 
     afterEach(() => {
@@ -199,6 +210,43 @@ describe('checkStorageAndUpdateBadge', () => {
             {},
             true,
         );
+    });
+
+    describe('badge/menu refresh queue (regression: overlapping refreshes)', () => {
+        beforeEach(() => {
+            vi.spyOn(chrome.storage.sync, 'get').mockImplementation(
+                (_keys, callback: (items: Record<string, string>) => void) => {
+                    callback({ mealieServer: 'https://mealie.tld', mealieApiToken: 'mock-token' });
+                },
+            );
+            vi.spyOn(chrome.tabs, 'query').mockImplementation(
+                () =>
+                    Promise.resolve([
+                        { ...mockActiveTab, url: 'https://recipe.org/refresh-storm' },
+                    ]) as unknown as void,
+            );
+        });
+
+        it('serializes many overlapping refresh calls — each completes scrape and menu update', async () => {
+            const mockTestScrapeUrlDetailed = vi.mocked(testScrapeUrlDetailed);
+            const mockUpdateContextMenu = vi.mocked(updateContextMenu);
+
+            mockTestScrapeUrlDetailed.mockImplementation(
+                () =>
+                    new Promise((resolve) =>
+                        setTimeout(() => resolve({ outcome: 'not-recipe' }), 15),
+                    ),
+            );
+
+            const n = 12;
+            const jobs = Array.from({ length: n }, () => checkStorageAndUpdateBadge());
+            await Promise.all(jobs);
+
+            // Same tab URL ⇒ only the first hop runs a remote scrape; later hops use cache but must
+            // still rebuild the menu. Starvation from overlapping lastCheckId used to yield ~0 menus.
+            expect(mockTestScrapeUrlDetailed).toHaveBeenCalledTimes(1);
+            expect(mockUpdateContextMenu).toHaveBeenCalledTimes(n);
+        });
     });
 
     it('should cache detection results for the same URL', async () => {


### PR DESCRIPTION
@joyjit thank you so much for these contributions! I've merged all three of your Firefox PRs into main via #123 and #124. Here's a summary of what landed:

- **#89** — MV3 manifest, gecko ID, AMO `data_collection_permissions` policy
- **#88** — Icon crop to true square dimensions (AMO lint fix)  
- **#90** — Reliability bundle (storage mirror, context menu race fix, URL normalization, popup hydration)

### Changes made on top
- Gecko ID changed to `shaplabs.net` (to match existing domain)
- Switched all Firefox builds to MV2 (per [WXT creator's recommendation](https://github.com/wxt-dev/wxt/issues/230#issuecomment-3882682570) — better user experience for `host_permissions`)
- Added `chrome.action` → `chrome.browserAction` fallback for MV2 compat
- Wrapped `chrome.storage.sync.get` and `chrome.tabs.query` in Promises for Firefox callback compat

The extension now runs great in Firefox via `pnpm dev:firefox`. Thanks again for getting this started!