### PR TITLE
chore: upgrade pnpm to v11.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,14 +59,5 @@
         "vitest": "^3.2.4",
         "wxt": "^0.20.26"
     },
-    "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
-    "pnpm": {
-        "packageExtensions": {
-            "minimatch@10.2.5": {
-                "dependencies": {
-                    "brace-expansion": "^5.0.6"
-                }
-            }
-        }
-    }
+    "packageManager": "pnpm@11.2.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+# pnpm 11: project-level pnpm settings live here, not in package.json's "pnpm" field
+allowBuilds:
+  esbuild: true
+  spawn-sync: true
+
+packageExtensions:
+  "minimatch@10.2.5":
+    dependencies:
+      brace-expansion: "^5.0.6"


### PR DESCRIPTION
## Summary

Upgrades pnpm from v10.28.2 to v11.2.2 and migrates project config to follow pnpm 11 conventions.

## Changes

- **`package.json`**: Updated `packageManager` to `pnpm@11.2.2`; removed `pnpm` settings field (no longer read by pnpm 11)
- **`pnpm-workspace.yaml`** *(new)*: Migrated `packageExtensions` from `package.json`; added explicit `allowBuilds` entries

## Security improvements (pnpm 11 defaults)

pnpm 11 ships these protections **on by default**:

| Setting | Behavior |
|---|---|
| `strictDepBuilds: true` | No package may run build scripts unless explicitly listed in `allowBuilds` |
| `minimumReleaseAge: 1440` | Newly published packages are blocked for 24h (supply-chain attack window) |
| `blockExoticSubdeps: true` | Blocks unusual protocol specifiers in transitive deps |

### Approved build-script packages

- **`esbuild`** — downloads native binary at install time (required by WXT bundler)
- **`spawn-sync`** — postinstall check; pulled in via `wxt → web-ext-run → fx-runner` (Mozilla Firefox extension runner)

Both were reviewed before approval. All CI runners will pick up `allowBuilds` from `pnpm-workspace.yaml` automatically — no interactive prompts.