### PR TITLE
fix(deps): force uuid>=11.1.1 to patch GHSA-w5hq-g745-h8pq

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  node-notifier>uuid: '>=11.1.1'
+
 packageExtensionsChecksum: sha256-xx97ir72Z/Od9tONlIEsbEVKGUrhc6tGfUeweqcsMOk=
 
 importers:
@@ -3974,9 +3977,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -7121,7 +7123,7 @@ snapshots:
       is-wsl: 2.2.0
       semver: 7.7.4
       shellwords: 0.1.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       which: 2.0.2
 
   normalize-package-data@6.0.2:
@@ -8238,7 +8240,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,13 @@ allowBuilds:
   esbuild: true
   spawn-sync: true
 
+overrides:
+  # node-notifier@10.0.1 (via wxt → web-ext-run) pins uuid@^8.3.2 which is
+  # vulnerable to GHSA-w5hq-g745-h8pq. Scoped to node-notifier only so the
+  # rest of the tree resolves its own preferred uuid version. node-notifier
+  # only calls uuid.v4(), API-compatible across all major versions.
+  node-notifier>uuid: ">=11.1.1"
+
 packageExtensions:
   "minimatch@10.2.5":
     dependencies:


### PR DESCRIPTION
## Summary

Resolves the moderate-severity Dependabot alert: [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) — buffer bounds-check bug in `uuid@<9.0.0`.

Closes https://github.com/mrshappy0/mini-mealie/security/dependabot/10

## Root cause

The vulnerable package comes through a chain that is already fully up to date:

```
uuid@8.3.2
└─┬ node-notifier@10.0.1   ← explicitly requires uuid@^8.3.2
  └─┬ web-ext-run@0.2.4    ← latest
    └─┬ wxt@0.20.26         ← latest
```

There is no upstream fix; `node-notifier@10.0.1` is the latest release and still pins `uuid@^8`.

## Fix

Added a `pnpm overrides` entry in `pnpm-workspace.yaml` to force `uuid>=11.1.1` (resolved to `14.0.0`).

`node-notifier` only uses `const { v4: uuid } = require('uuid')` — a single named export to generate a Windows named-pipe ID. `v4()` is API-compatible across all uuid major versions; the breaking changes in v9+ do not affect this usage.

## Impact

- **Dev-only**: `uuid` is never bundled into the extension output; the vulnerable code only runs on local dev machines / CI runners.
- Tests and typecheck pass with `uuid@14.0.0`.