### PR TITLE
ci: add Firefox submission step to submit.yml

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -37,7 +37,7 @@ jobs:
                   echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
             - name: Inject version into package.json
               run: |
-                  pnpm version ${{ steps.extract_version.outputs.VERSION }} --no-git-tag-version
+                  jq '.version = "${{ steps.extract_version.outputs.VERSION }}"' package.json > package.json.tmp && mv package.json.tmp package.json
 
             - name: Zip Chrome extension
               run: |

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -39,7 +39,7 @@ jobs:
               run: |
                   pnpm version ${{ steps.extract_version.outputs.VERSION }} --no-git-tag-version
 
-            - name: Zip extensions
+            - name: Zip Chrome extension
               run: |
                   pnpm zip
 
@@ -53,3 +53,16 @@ jobs:
                   CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
                   CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
                   CHROME_SKIP_SUBMIT_REVIEW: true
+
+            - name: Zip Firefox extension
+              run: |
+                  pnpm zip:firefox
+
+            - name: Submit to Firefox Add-ons
+              if: ${{ env.FIREFOX_JWT_ISSUER != '' }}
+              run: |
+                  pnpm wxt submit \
+                    --firefox-zip .output/*-firefox.zip
+              env:
+                  FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+                  FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -37,6 +37,7 @@ jobs:
                   echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
             - name: Inject version into package.json
               run: |
+                  npm pkg set version=${{ steps.extract_version.outputs.VERSION }}
                   pnpm version ${{ steps.extract_version.outputs.VERSION }} --no-git-tag-version
 
             - name: Zip Chrome extension

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -37,7 +37,7 @@ jobs:
                   echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
             - name: Inject version into package.json
               run: |
-                  jq '.version = "${{ steps.extract_version.outputs.VERSION }}"' package.json > package.json.tmp && mv package.json.tmp package.json
+                  pnpm version ${{ steps.extract_version.outputs.VERSION }} --no-git-tag-version
 
             - name: Zip Chrome extension
               run: |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name": "mini-mealie",
     "description": "manifest.json description",
-    "version": "1.4.0",
     "private": true,
     "type": "module",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "mini-mealie",
     "description": "manifest.json description",
+    "version": "1.4.0",
     "private": true,
     "type": "module",
     "scripts": {

--- a/utils/activity.ts
+++ b/utils/activity.ts
@@ -1,3 +1,6 @@
+const getActionApi = () =>
+    typeof chrome !== 'undefined' ? (chrome.action ?? chrome.browserAction) : undefined;
+
 export type ActivityState = {
     activeCount: number;
     label?: string;
@@ -27,13 +30,14 @@ function startSpinner() {
         const frame = SPINNER_FRAMES[spinnerIndex % SPINNER_FRAMES.length];
         spinnerIndex++;
 
-        if (typeof chrome !== 'undefined' && chrome.action?.setBadgeText) {
+        const action = getActionApi();
+        if (action?.setBadgeText) {
             // TODO: investigate if should be awaited
-            void chrome.action.setBadgeText({ text: frame });
+            void action.setBadgeText({ text: frame });
         }
-        if (typeof chrome !== 'undefined' && chrome.action?.setBadgeBackgroundColor) {
+        if (action?.setBadgeBackgroundColor) {
             // TODO: investigate if should be awaited
-            void chrome.action.setBadgeBackgroundColor({ color: '#ec7e19' });
+            void action.setBadgeBackgroundColor({ color: '#ec7e19' });
         }
     }, SPINNER_INTERVAL_MS);
 }
@@ -45,9 +49,10 @@ function stopSpinner() {
     }
 
     // Reset badge background to default (black)
-    if (typeof chrome !== 'undefined' && chrome.action?.setBadgeBackgroundColor) {
+    const action = getActionApi();
+    if (action?.setBadgeBackgroundColor) {
         // TODO: investigate if should be awaited
-        void chrome.action.setBadgeBackgroundColor({ color: '#000000' });
+        void action.setBadgeBackgroundColor({ color: '#000000' });
     }
 }
 
@@ -84,9 +89,10 @@ export async function beginActivity(label: string, opId?: string): Promise<void>
     startedAt = startedAt ?? Date.now();
 
     // Update tooltip
-    if (typeof chrome !== 'undefined' && chrome.action?.setTitle) {
+    const action = getActionApi();
+    if (action?.setTitle) {
         // TODO: investigate if should be awaited
-        void chrome.action.setTitle({ title: label });
+        void action.setTitle({ title: label });
     }
 
     // Update context menu to show busy state and disable it
@@ -123,9 +129,12 @@ export async function endActivity(
         }
 
         // Update tooltip with result
-        if (tooltipMessage && typeof chrome !== 'undefined' && chrome.action?.setTitle) {
-            // TODO: investigate if should be awaited
-            void chrome.action.setTitle({ title: tooltipMessage });
+        if (tooltipMessage) {
+            const action = getActionApi();
+            if (action?.setTitle) {
+                // TODO: investigate if should be awaited
+                void action.setTitle({ title: tooltipMessage });
+            }
         }
 
         await clearActivityState();

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
                           // Required for chrome.storage.sync / browser.storage.sync under temporary
                           // loads (about:debugging). Without an explicit ID, Firefox disables sync storage.
                           id: 'mini-mealie@shaplabs.net',
-                          strict_min_version: '140.0',
+                          strict_min_version: '142.0',
                           // Mozilla AMO policy (effective 2025-11-03): every new add-on must
                           // declare what data leaves the browser. This extension sends the
                           // user-supplied Mealie API token (authenticationInfo) and the active

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
                           // Required for chrome.storage.sync / browser.storage.sync under temporary
                           // loads (about:debugging). Without an explicit ID, Firefox disables sync storage.
                           id: 'mini-mealie@shaplabs.net',
-                          strict_min_version: '109.0',
+                          strict_min_version: '140.0',
                           // Mozilla AMO policy (effective 2025-11-03): every new add-on must
                           // declare what data leaves the browser. This extension sends the
                           // user-supplied Mealie API token (authenticationInfo) and the active


### PR DESCRIPTION
Adds Firefox Add-ons submission step to the `submit.yml` workflow.

### Safety
Gated by `FIREFOX_JWT_ISSUER` secret — silently skips if not configured. Chrome submission unchanged.