### PR TITLE
fix(ci): remove pnpm version step that conflicts with npm pkg set

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -38,7 +38,6 @@ jobs:
             - name: Inject version into package.json
               run: |
                   npm pkg set version=${{ steps.extract_version.outputs.VERSION }}
-                  pnpm version ${{ steps.extract_version.outputs.VERSION }} --no-git-tag-version
 
             - name: Zip Chrome extension
               run: |


### PR DESCRIPTION
`npm pkg set` writes the version into package.json, which dirties the working tree. Running `pnpm version` afterward fails with `ERR_PNPM_UNCLEAN_WORKING_TREE`.

`npm pkg set` alone is sufficient — WXT reads the version from `package.json` for manifest generation.