### PR TITLE
feat: clearer activity log button label and proper badge background reset

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -475,7 +475,7 @@ function ActivityLog() {
     return (
         <div className="activity-log">
             <button className="activity-log-link" onClick={handleOpenLogs}>
-                Recent Activity ▶
+                Open Activity Log ↗
             </button>
         </div>
     );

--- a/utils/badge.ts
+++ b/utils/badge.ts
@@ -21,5 +21,8 @@ export const showBadge = (text: string, duration?: number) => {
 export const clearBadge = () => {
     const action = getActionApi();
     if (!action?.setBadgeText) return;
+    if (action.setBadgeBackgroundColor) {
+        void action.setBadgeBackgroundColor({ color: '#000000' });
+    }
     void action.setBadgeText({ text: '' });
 };


### PR DESCRIPTION
Two small UX polish items:

- **Activity log button**: "Recent Activity ▶" → "Open Activity Log ↗". The old label suggested an inline toggle, but clicking opens a new tab. The new label sets correct expectations.

- **Badge background reset**: `clearBadge()` now also resets the badge background color to black, not just the text. This makes it a proper, self-contained cleanup function regardless of badge state.