### PR TITLE
fix(ci): add missing FIREFOX_EXTENSION_ID to submit workflow

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -64,5 +64,6 @@ jobs:
                   pnpm wxt submit \
                     --firefox-zip .output/*-firefox.zip
               env:
+                  FIREFOX_EXTENSION_ID: 'mini-mealie@shaplabs.net'
                   FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
                   FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}


### PR DESCRIPTION
The Firefox submit step was missing the `FIREFOX_EXTENSION_ID` env var, which `wxt submit` requires. Extension ID (`mini-mealie@shaplabs.net`) is public — already in the manifest — so it's hardcoded rather than stored as a secret.