### PR TITLE
ci: inject version from latest tag in firefox debug workflow

### DIFF
--- a/.github/workflows/submit-firefox-debug.yml
+++ b/.github/workflows/submit-firefox-debug.yml
@@ -18,6 +18,8 @@ jobs:
         steps:
             - name: Checkout Code
               uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
 
             - name: Install pnpm
               uses: pnpm/action-setup@v6
@@ -33,6 +35,13 @@ jobs:
 
             - name: Install dependencies
               run: pnpm install
+
+            - name: Inject version from latest tag
+              run: |
+                  TAG=$(git describe --tags --abbrev=0)
+                  VERSION=${TAG#v}
+                  echo "Latest tag: $TAG → version: $VERSION"
+                  npm pkg set version="$VERSION"
 
             - name: Build & Zip for Firefox
               run: pnpm zip:firefox


### PR DESCRIPTION
The debug workflow was zipping with version "0.0.0" because it never injected the real version from the release. This adds:

- `fetch-depth: 0` on checkout to get all tags
- A step that extracts the version from `git describe --tags` and injects it into `package.json` before building

Now the firefox zip will have the correct version matching what's published.