### PR TITLE
fix(ci): add firefox sources zip and listed channel to submit workflow

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -62,7 +62,9 @@ jobs:
               if: ${{ env.FIREFOX_JWT_ISSUER != '' }}
               run: |
                   pnpm wxt submit \
-                    --firefox-zip .output/*-firefox.zip
+                    --firefox-zip .output/*-firefox.zip \
+                    --firefox-sources-zip .output/*-sources.zip \
+                    --firefox-channel=listed
               env:
                   FIREFOX_EXTENSION_ID: 'mini-mealie@shaplabs.net'
                   FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}


### PR DESCRIPTION
The production submit workflow was missing `--firefox-sources-zip` and `--firefox-channel=listed` — the two flags that made the Firefox [debug workflow](https://github.com/mrshappy0/mini-mealie/actions/runs/27566633110) succeed. This brings them into `submit.yml`.