### PR TITLE
ci: fix firefox submit — add sources-zip, listed channel, and debug version injection

### DIFF
--- a/.github/workflows/submit-firefox-debug.yml
+++ b/.github/workflows/submit-firefox-debug.yml
@@ -18,6 +18,8 @@ jobs:
         steps:
             - name: Checkout Code
               uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
 
             - name: Install pnpm
               uses: pnpm/action-setup@v6
@@ -33,6 +35,13 @@ jobs:
 
             - name: Install dependencies
               run: pnpm install
+
+            - name: Inject version from latest tag
+              run: |
+                  TAG=$(git describe --tags --abbrev=0)
+                  VERSION=${TAG#v}
+                  echo "Latest tag: $TAG → version: $VERSION"
+                  npm pkg set version="$VERSION"
 
             - name: Build & Zip for Firefox
               run: pnpm zip:firefox

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -62,7 +62,9 @@ jobs:
               if: ${{ env.FIREFOX_JWT_ISSUER != '' }}
               run: |
                   pnpm wxt submit \
-                    --firefox-zip .output/*-firefox.zip
+                    --firefox-zip .output/*-firefox.zip \
+                    --firefox-sources-zip .output/*-sources.zip \
+                    --firefox-channel=listed
               env:
                   FIREFOX_EXTENSION_ID: 'mini-mealie@shaplabs.net'
                   FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}


### PR DESCRIPTION
Two fixes, both verified by the [successful debug submission](https://github.com/mrshappy0/mini-mealie/actions/runs/27566633110):

1. **Production submit workflow** — add `--firefox-sources-zip` and `--firefox-channel=listed` (matches debug workflow that succeeded)
2. **Debug workflow** — inject version from latest git tag instead of defaulting to "0.0.0"