### PR TITLE
chore: merge dependabot PRs — eslint 10.6.0, globals 17.7.0, prettier 3.9.4, resend 6.16.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "*"
+applyTo: '*'
 ---
 
 # Copilot instructions (mini-mealie)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'

--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -36,31 +36,31 @@ jobs:
             - name: Resolve Release Info
               id: release_info
               run: |
-                TAG_NAME="${{ github.event.release.tag_name }}"
-                BODY="${{ github.event.release.body }}"
-      
-                if [ -z "$TAG_NAME" ] || [ -z "$BODY" ]; then
-                  echo "Falling back to latest release..."
-                  release=$(gh api repos/${{ github.repository }}/releases/latest)
-                  TAG_NAME=$(echo "$release" | jq -r .tag_name)
-                  BODY=$(echo "$release" | jq -r .body)
-                fi
-      
-                # Proper escaping of multiline values
-                echo "RELEASE_TAG<<EOF" >> $GITHUB_ENV
-                echo "$TAG_NAME" >> $GITHUB_ENV
-                echo "EOF" >> $GITHUB_ENV
-      
-                echo "RELEASE_BODY<<EOF" >> $GITHUB_ENV
-                echo "$BODY" >> $GITHUB_ENV
-                echo "EOF" >> $GITHUB_ENV
+                  TAG_NAME="${{ github.event.release.tag_name }}"
+                  BODY="${{ github.event.release.body }}"
+
+                  if [ -z "$TAG_NAME" ] || [ -z "$BODY" ]; then
+                    echo "Falling back to latest release..."
+                    release=$(gh api repos/${{ github.repository }}/releases/latest)
+                    TAG_NAME=$(echo "$release" | jq -r .tag_name)
+                    BODY=$(echo "$release" | jq -r .body)
+                  fi
+
+                  # Proper escaping of multiline values
+                  echo "RELEASE_TAG<<EOF" >> $GITHUB_ENV
+                  echo "$TAG_NAME" >> $GITHUB_ENV
+                  echo "EOF" >> $GITHUB_ENV
+
+                  echo "RELEASE_BODY<<EOF" >> $GITHUB_ENV
+                  echo "$BODY" >> $GITHUB_ENV
+                  echo "EOF" >> $GITHUB_ENV
               env:
-                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Send Release Email via Resend
               env:
-                RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-                RESEND_AUDIENCE_ID: ${{ vars.RESEND_AUDIENCE_ID}}
-                RELEASE_TAG: ${{ env.RELEASE_TAG }}
-                RELEASE_BODY: ${{ env.RELEASE_BODY }}
+                  RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+                  RESEND_AUDIENCE_ID: ${{ vars.RESEND_AUDIENCE_ID}}
+                  RELEASE_TAG: ${{ env.RELEASE_TAG }}
+                  RELEASE_BODY: ${{ env.RELEASE_BODY }}
               run: pnpm exec tsx scripts/send-release-email.ts

--- a/.github/workflows/watch-eslint-plugin-react.yml
+++ b/.github/workflows/watch-eslint-plugin-react.yml
@@ -1,81 +1,81 @@
 name: Watch eslint-plugin-react Upstream Fix
 
 on:
-  schedule:
-    - cron: '0 8 */3 * *'  # Every 3 days at 8am UTC
-  workflow_dispatch:        # Manual trigger
+    schedule:
+        - cron: '0 8 */3 * *' # Every 3 days at 8am UTC
+    workflow_dispatch: # Manual trigger
 
 jobs:
-  check-pr-merged:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
-    steps:
-      - name: Check if upstream PR #3979 is merged
-        id: check
-        run: |
-          MERGED=$(gh pr view 3979 \
-            --repo jsx-eslint/eslint-plugin-react \
-            --json merged \
-            --jq '.merged' 2>/dev/null || echo "false")
+    check-pr-merged:
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+            contents: read
+        steps:
+            - name: Check if upstream PR #3979 is merged
+              id: check
+              run: |
+                  MERGED=$(gh pr view 3979 \
+                    --repo jsx-eslint/eslint-plugin-react \
+                    --json merged \
+                    --jq '.merged' 2>/dev/null || echo "false")
 
-          echo "merged=$MERGED" >> $GITHUB_OUTPUT
+                  echo "merged=$MERGED" >> $GITHUB_OUTPUT
 
-          if [ "$MERGED" = "true" ]; then
-            echo "Upstream PR #3979 has been merged!"
-            VERSION=$(gh pr view 3979 \
-              --repo jsx-eslint/eslint-plugin-react \
-              --json mergeCommit \
-              --jq '.mergeCommit.oid // "unknown"' 2>/dev/null)
-            echo "merge_commit=$VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "PR #3979 not yet merged."
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+                  if [ "$MERGED" = "true" ]; then
+                    echo "Upstream PR #3979 has been merged!"
+                    VERSION=$(gh pr view 3979 \
+                      --repo jsx-eslint/eslint-plugin-react \
+                      --json mergeCommit \
+                      --jq '.mergeCommit.oid // "unknown"' 2>/dev/null)
+                    echo "merge_commit=$VERSION" >> $GITHUB_OUTPUT
+                  else
+                    echo "PR #3979 not yet merged."
+                  fi
+              env:
+                  GH_TOKEN: ${{ github.token }}
 
-      - name: Notify via GitHub Issue
-        if: steps.check.outputs.merged == 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { merged, merge_commit } = '${{ steps.check.outputs }}';
+            - name: Notify via GitHub Issue
+              if: steps.check.outputs.merged == 'true'
+              uses: actions/github-script@v9
+              with:
+                  script: |
+                      const { merged, merge_commit } = '${{ steps.check.outputs }}';
 
-            const title = 'eslint-plugin-react upstream fix has been merged';
-            const body = `The upstream ESLint 10 compatibility fix ([jsx-eslint/eslint-plugin-react#3979](https://github.com/jsx-eslint/eslint-plugin-react/pull/3979)) has been merged.
+                      const title = 'eslint-plugin-react upstream fix has been merged';
+                      const body = `The upstream ESLint 10 compatibility fix ([jsx-eslint/eslint-plugin-react#3979](https://github.com/jsx-eslint/eslint-plugin-react/pull/3979)) has been merged.
 
-            **Action required:** Revert \`eslint-plugin-react\` in \`package.json\` from the forked version back to the npm registry:
+                      **Action required:** Revert \`eslint-plugin-react\` in \`package.json\` from the forked version back to the npm registry:
 
-            \`\`\`diff
-            -"eslint-plugin-react": "github:ledsun/eslint-plugin-react#update-deprecated-calls-v8",
-            +"eslint-plugin-react": "^7.38.0",
-            \`\`\`
+                      \`\`\`diff
+                      -"eslint-plugin-react": "github:ledsun/eslint-plugin-react#update-deprecated-calls-v8",
+                      +"eslint-plugin-react": "^7.38.0",
+                      \`\`\`
 
-            Merge commit: \`${merge_commit}\`
-            `;
+                      Merge commit: \`${merge_commit}\`
+                      `;
 
-            // Check for existing open issue
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: ['tech-debt'],
-              per_page: 100,
-            });
+                      // Check for existing open issue
+                      const { data: issues } = await github.rest.issues.listForRepo({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        state: 'open',
+                        labels: ['tech-debt'],
+                        per_page: 100,
+                      });
 
-            const exists = issues.some(i => i.title === title);
-            if (exists) {
-              console.log('Issue already exists, skipping.');
-              return;
-            }
+                      const exists = issues.some(i => i.title === title);
+                      if (exists) {
+                        console.log('Issue already exists, skipping.');
+                        return;
+                      }
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body,
-              labels: ['tech-debt'],
-            });
+                      await github.rest.issues.create({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        title,
+                        body,
+                        labels: ['tech-debt'],
+                      });
 
-            console.log('Created issue to track eslint-plugin-react revert.');
+                      console.log('Created issue to track eslint-plugin-react revert.');

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,4 @@
 {
-    "recommendations": [
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode"
-    ],
+    "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
     "unwantedRecommendations": []
 }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Mini Mealie is a browser extension built using WXT and React, designed to speed 
     - Pre-populate your credentials from `.env.local` (if configured)
 
     For Firefox development, use:
+
     ```bash
     pnpm dev:firefox
     ```

--- a/docs/ai-implementation/event-logging-and-activity-ux.md
+++ b/docs/ai-implementation/event-logging-and-activity-ux.md
@@ -3,35 +3,43 @@
 Date: 2026-01-31
 
 ## Problem Summary
+
 Mini Mealie relies on `showBadge()` to communicate success/failure. When network calls are slow, time out, or fail, badge updates can be missed (user isn’t watching the toolbar). That leads to “rage clicking” and a sense the extension is broken.
 
 We want two improvements:
+
 1. **A lightweight event log** for major extension actions (connect/profile fetch, recipe creation URL/HTML, page HTML capture, recipe detection/test-scrape).
 2. **Clear “in progress” UX** while operations run (badge spinner/loading, optional tooltip text, context menu disabled/retitled).
 
 Low effort is a priority: invest most work into the event system, keep UI minimal.
 
 ## Goals
+
 - Provide a **durable, user-visible trace** of “what happened” for major features.
 - Make “something is happening” obvious during long calls.
 - Avoid large permissions or heavy UI work.
 - Keep changes incremental and testable.
 
 ## Non-Goals (for MVP)
+
 - Full analytics/telemetry.
 - Remote log streaming.
 - Per-site recipe parsing or deep UI workflows.
 - Complex DevTools integration (opening the SW console automatically).
 
 ## Key Constraints / Realities
+
 - Extension action badges are easy to miss; **tooltips** (`chrome.action.setTitle`) persist on hover.
 - Popups are ephemeral; users may never open it during a context-menu action.
 - The service worker stays alive while a Promise chain is pending, so a simple spinner interval is viable during active work.
 - Sync storage is not ideal for logs. Prefer **`chrome.storage.local`** (persistent) or **`chrome.storage.session`** (ephemeral).
 
 ## Proposed Strategy (Recommended MVP)
+
 ### 1) Build an event logger (core)
+
 Create a small logging module that:
+
 - Stores logs in a **ring buffer** (fixed size, e.g. 300 entries).
 - Persists to `chrome.storage.local` under a single key (e.g. `miniMealie.eventLog`).
 - Emits structured events with correlation ids:
@@ -40,75 +48,88 @@ Create a small logging module that:
 // shape idea
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 export type LogEvent = {
-  id: string; // uuid or timestamp-counter
-  ts: number; // Date.now()
-  level: LogLevel;
-  feature: 'auth' | 'recipe-create' | 'recipe-detect' | 'html-capture' | 'network' | 'storage';
-  action: string; // e.g. 'createFromUrl', 'getUser', 'testScrape'
-  phase?: 'start' | 'progress' | 'success' | 'failure';
-  opId?: string; // correlation id for a single operation
-  message: string;
-  data?: Record<string, unknown>; // safe metadata (no tokens)
+    id: string; // uuid or timestamp-counter
+    ts: number; // Date.now()
+    level: LogLevel;
+    feature: 'auth' | 'recipe-create' | 'recipe-detect' | 'html-capture' | 'network' | 'storage';
+    action: string; // e.g. 'createFromUrl', 'getUser', 'testScrape'
+    phase?: 'start' | 'progress' | 'success' | 'failure';
+    opId?: string; // correlation id for a single operation
+    message: string;
+    data?: Record<string, unknown>; // safe metadata (no tokens)
 };
 ```
 
 Important policy:
+
 - **Never log API tokens**.
 - When logging server URLs, consider storing only origin.
 
 Core APIs:
+
 - `logEvent(event)`
 - `withOperation({feature, action, title}, fn)` → handles `start/success/failure` + duration.
 - `getRecentEvents()` and `clearEvents()`.
 
 ### 2) Add an “activity indicator” (core UX)
+
 Define a shared “activity state” that answers:
+
 - Is an operation active? (`activeCount > 0`)
-- What is the current top-level activity label? (e.g. “Creating recipe (HTML)…”) 
+- What is the current top-level activity label? (e.g. “Creating recipe (HTML)…”)
 
 Implementation idea:
+
 - Maintain an in-memory counter in background/service worker.
 - Also write a simplified state to storage so popup/pages can read it:
 
 ```ts
 type ActivityState = {
-  activeCount: number;
-  label?: string;
-  opId?: string;
-  startedAt?: number;
+    activeCount: number;
+    label?: string;
+    opId?: string;
+    startedAt?: number;
 };
 ```
 
 ### 3) Badge loading spinner (core UX)
+
 While `activeCount > 0`:
+
 - Start a timer that cycles badge text every ~150–250ms using Unicode spinner frames.
-  - Example frames: `['◐','◓','◑','◒']` or `['⠋','⠙','⠹','⠸','⠼','⠴','⠦','⠧','⠇','⠏']`.
+    - Example frames: `['◐','◓','◑','◒']` or `['⠋','⠙','⠹','⠸','⠼','⠴','⠦','⠧','⠇','⠏']`.
 - Optionally set badge background to a “working” color.
 
 On completion:
+
 - Stop spinner.
 - Show ✅/❌ for a few seconds (existing behavior).
 - Update tooltip title with the last result (“Recipe created successfully” / “Recipe creation failed (timeout)” etc).
 
 ### 4) Context menu behavior during activity (core UX)
+
 When an operation is active:
+
 - Update the context menu item title to reflect activity (e.g. “Creating recipe…”).
 - Disable the menu item (`enabled: false`) until activity completes.
 
 This prevents repeated clicks and communicates “busy”.
 
 ## UI Options for Logs (choose 1 for MVP)
+
 ### Option A (lowest effort): show logs in popup
+
 - Add a small “Recent activity” panel in the existing popup.
 - It reads from `chrome.storage.local` and re-renders on `chrome.storage.onChanged`.
 - Provide actions:
-  - “Copy logs” (copy JSON / text summary)
-  - “Clear logs”
+    - “Copy logs” (copy JSON / text summary)
+    - “Clear logs”
 
 Pros: minimal surface area, no new entrypoints.
 Cons: user must open popup; not great for live watching.
 
 ### Option B (recommended if you want ‘streaming’): add an internal Logs page
+
 - Add a new extension page (opens as a normal tab) that streams logs.
 - Page listens to storage changes and renders a scrollable list with filters.
 
@@ -116,6 +137,7 @@ Pros: best UX for long operations, easy to keep open.
 Cons: slightly more setup (new entrypoint/page).
 
 ### Option C (ultra-low effort but not ideal): only console logging + helper link
+
 - Log to `console` in background.
 - Add a “How to view logs” link in popup that opens instructions.
 
@@ -125,40 +147,47 @@ Cons: not user friendly; also Chrome doesn’t reliably allow opening the SW con
 **Recommendation:** Start with **Option A** (popup) for MVP, and keep Option B as Phase 2 if desired.
 
 ## Where to Instrument (MVP)
+
 - Auth/profile fetch: `getUser()` (popup connect flow)
 - Recipe creation (URL): `createRecipeFromURL()`
 - Recipe creation (HTML): `getPageHTML()` + `createRecipeFromHTML()`
 - Recipe detection: `testScrapeUrlDetailed()` (likely `debug` or `info` with sampling to avoid spam)
 
 ## Acceptance Criteria (MVP)
+
 - When “Create recipe” is triggered:
-  - Badge shows a spinner until done.
-  - Context menu becomes disabled while active.
-  - On completion, badge shows ✅/❌ and tooltip explains outcome.
-  - Logs record start/end + any error details (sanitized).
+    - Badge shows a spinner until done.
+    - Context menu becomes disabled while active.
+    - On completion, badge shows ✅/❌ and tooltip explains outcome.
+    - Logs record start/end + any error details (sanitized).
 - When “Connect Mealie” runs:
-  - Logs record start/success/failure.
+    - Logs record start/success/failure.
 - Logs are visible (Option A) in the popup and can be cleared.
 
 ## Implementation Phases
+
 ### Phase 1: Logging + Activity State
+
 - Add `utils/logging/*` (event log + helpers)
 - Add `utils/activity/*` (activeCount + badge spinner)
 - Instrument the existing flows (connect + create recipe)
 - Add minimal popup UI panel for logs (Option A)
 
 ### Phase 2: Stronger UX
+
 - Add context-menu disable/enable helper
 - Add tooltip updates everywhere
 - Add “View logs” button to open logs page (if doing Option B)
 
 ### Phase 3: Nice-to-haves
+
 - Severity filtering
 - Export logs as file
 - Correlation id grouping (“operation cards”)
 - Sampling/throttling for recipe detection logs
 
 ## Open Decisions (please confirm)
+
 1. Logs storage: `chrome.storage.local` (persistent) vs `chrome.storage.session` (ephemeral)
 2. Log visibility MVP: Option A (popup) vs Option B (tab)
 3. Spinner frames: simple 4-frame unicode vs braille 10-frame

--- a/docs/ai-implementation/import-tags-categories-feature.md
+++ b/docs/ai-implementation/import-tags-categories-feature.md
@@ -43,12 +43,12 @@
 ```typescript
 // URL mode
 {
-    url, includeTags, includeCategories;
+    (url, includeTags, includeCategories);
 }
 
 // HTML mode
 {
-    data, url, includeTags, includeCategories;
+    (data, url, includeTags, includeCategories);
 }
 ```
 

--- a/docs/developers-guide/code-contributions.md
+++ b/docs/developers-guide/code-contributions.md
@@ -1,4 +1,7 @@
 ## Any contributions you make will be under the AGPL Software License
+
 …r submissions are understood to be under the same [AGPL License](https://choosealicense.com/licenses/agpl-3.0/) that c…
+
 ## License
+
 By contributing, you agree that your contributions will be licensed under its AGPL License.

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mini Mealie</title>
-    <meta name="manifest.type" content="browser_action" />
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="./main.tsx"></script>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Mini Mealie</title>
+        <meta name="manifest.type" content="browser_action" />
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="./main.tsx"></script>
+    </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "normalize-url": "^9.0.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "resend": "^6.12.3"
+        "resend": "^6.16.0"
     },
     "devDependencies": {
         "@commitlint/cli": "^21.2.0",
@@ -43,15 +43,15 @@
         "@vitest/coverage-v8": "^4.1.9",
         "@vitest/ui": "^4.1.9",
         "@wxt-dev/module-react": "^1.2.2",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-formatter-compact": "^9.0.1",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-react": "github:ledsun/eslint-plugin-react#update-deprecated-calls-v8",
         "eslint-plugin-security": "^4.0.0",
         "eslint-plugin-simple-import-sort": "^13.0.0",
-        "globals": "^17.6.0",
-        "prettier": "^3.8.3",
+        "globals": "^17.7.0",
+        "prettier": "^3.9.4",
         "semantic-release": "^25.0.5",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.7(react@19.2.7)
       resend:
-        specifier: ^6.12.3
-        version: 6.12.4
+        specifier: ^6.16.0
+        version: 6.16.0
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.2.0
@@ -41,7 +41,7 @@ importers:
         version: 1.3.0
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
+        version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
       '@html-eslint/parser':
         specifier: ^0.62.0
         version: 0.62.0
@@ -74,34 +74,34 @@ importers:
         version: 4.1.9(vitest@4.1.9)
       '@wxt-dev/module-react':
         specifier: ^1.2.2
-        version: 1.2.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(wxt@0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4))
+        version: 1.2.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(wxt@0.20.26(@types/node@25.9.3)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4))
       eslint:
-        specifier: ^10.5.0
-        version: 10.5.0(jiti@2.7.0)
+        specifier: ^10.6.0
+        version: 10.6.0(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.5.0(jiti@2.7.0))
+        version: 10.1.8(eslint@10.6.0(jiti@2.7.0))
       eslint-formatter-compact:
         specifier: ^9.0.1
         version: 9.0.1
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.4)
+        version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0))(prettier@3.9.4)
       eslint-plugin-react:
         specifier: github:ledsun/eslint-plugin-react#update-deprecated-calls-v8
-        version: https://codeload.github.com/ledsun/eslint-plugin-react/tar.gz/635cd2ceb3c0af1254866338871776e2fa762c8e(eslint@10.5.0(jiti@2.7.0))
+        version: https://codeload.github.com/ledsun/eslint-plugin-react/tar.gz/635cd2ceb3c0af1254866338871776e2fa762c8e(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-security:
         specifier: ^4.0.0
         version: 4.0.1
       eslint-plugin-simple-import-sort:
         specifier: ^13.0.0
-        version: 13.0.0(eslint@10.5.0(jiti@2.7.0))
+        version: 13.0.0(eslint@10.6.0(jiti@2.7.0))
       globals:
-        specifier: ^17.6.0
-        version: 17.6.0
+        specifier: ^17.7.0
+        version: 17.7.0
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.4
+        specifier: ^3.9.4
+        version: 3.9.4
       semantic-release:
         specifier: ^25.0.5
         version: 25.0.5(typescript@6.0.3)
@@ -113,13 +113,13 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.61.1
-        version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
       wxt:
         specifier: ^0.20.26
-        version: 0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4)
+        version: 0.20.26(@types/node@25.9.3)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4)
 
 packages:
 
@@ -1692,8 +1692,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.5.0:
-    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
+  eslint@10.6.0:
+    resolution: {integrity: sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1935,8 +1935,8 @@ packages:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
     engines: {node: '>=20'}
 
-  globals@17.6.0:
-    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -3103,8 +3103,8 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3234,8 +3234,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.12.4:
-    resolution: {integrity: sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==}
+  resend@6.16.0:
+    resolution: {integrity: sha512-SaKISwHtxvAxneF84Njgnzg+zdngUu1vOT/paRU1De9QF+zXQR3GnwJHSh+mpJPjUhsGD4WxYi5CfKkXMkDqwg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -4337,9 +4337,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.6.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -4371,9 +4371,9 @@ snapshots:
       '@eslint/css-tree': 4.0.4
       '@eslint/plugin-kit': 0.7.2
 
-  '@eslint/js@10.0.1(eslint@10.5.0(jiti@2.7.0))':
+  '@eslint/js@10.0.1(eslint@10.6.0(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -4737,15 +4737,15 @@ snapshots:
 
   '@types/webextension-polyfill@0.12.5': {}
 
-  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -4753,14 +4753,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -4783,13 +4783,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4812,13 +4812,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -4915,11 +4915,11 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.2.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(wxt@0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4))':
+  '@wxt-dev/module-react@1.2.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(wxt@0.20.26(@types/node@25.9.3)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4))':
     dependencies:
       '@vitejs/plugin-react': 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
-      wxt: 0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4)
+      wxt: 0.20.26(@types/node@25.9.3)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - babel-plugin-react-compiler
@@ -5681,23 +5681,23 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
 
   eslint-formatter-compact@9.0.1: {}
 
-  eslint-plugin-prettier@5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.4):
+  eslint-plugin-prettier@5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0))(prettier@3.9.4):
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
-      prettier: 3.8.4
+      eslint: 10.6.0(jiti@2.7.0)
+      prettier: 3.9.4
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@10.5.0(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@10.6.0(jiti@2.7.0))
 
-  eslint-plugin-react@https://codeload.github.com/ledsun/eslint-plugin-react/tar.gz/635cd2ceb3c0af1254866338871776e2fa762c8e(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-react@https://codeload.github.com/ledsun/eslint-plugin-react/tar.gz/635cd2ceb3c0af1254866338871776e2fa762c8e(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -5705,7 +5705,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.3
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
@@ -5723,9 +5723,9 @@ snapshots:
     dependencies:
       safe-regex: 2.1.1
 
-  eslint-plugin-simple-import-sort@13.0.0(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-simple-import-sort@13.0.0(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -5738,9 +5738,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0(jiti@2.7.0):
+  eslint@10.6.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.6.0
@@ -6029,7 +6029,7 @@ snapshots:
     dependencies:
       ini: 6.0.0
 
-  globals@17.6.0: {}
+  globals@17.7.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -7062,7 +7062,7 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier@3.8.4: {}
+  prettier@3.9.4: {}
 
   pretty-ms@9.3.0:
     dependencies:
@@ -7210,7 +7210,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resend@6.12.4:
+  resend@6.16.0:
     dependencies:
       postal-mime: 2.7.4
       standardwebhooks: 1.0.0
@@ -7745,13 +7745,13 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.5.0(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.6.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -8040,7 +8040,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4):
+  wxt@0.20.26(@types/node@25.9.3)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rolldown@1.0.3)(tsx@4.22.4):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0
@@ -8085,7 +8085,7 @@ snapshots:
       vite-node: 6.0.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
       web-ext-run: 0.2.4
     optionalDependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.6.0(jiti@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,31 +6,31 @@
 #    See AGENTS.md for details.
 #
 allowBuilds:
-  esbuild: true
-  spawn-sync: true
+    esbuild: true
+    spawn-sync: true
 
 overrides:
-  # node-notifier@10.0.1 (via wxt → web-ext-run) pins uuid@^8.3.2 which is
-  # vulnerable to GHSA-w5hq-g745-h8pq. Scoped to node-notifier only so the
-  # rest of the tree resolves its own preferred uuid version. node-notifier
-  # only calls uuid.v4(), API-compatible across all major versions.
-  node-notifier>uuid: ">=11.1.1"
-  # GHSA-w7jw-789q-3m8p: shell-quote quote() newline escaping in .op values.
-  # fx-runner@1.4.0 pins shell-quote@1.7.3; fx-runner@1.5.0 already uses 1.8.4
-  # but web-ext-run@0.2.4 (no newer release) still depends on fx-runner@1.4.0.
-  fx-runner>shell-quote: ">=1.8.4"
-  # GHSA-ph9p-34f9-6g65: tmp path traversal via unsanitized prefix/postfix.
-  # web-ext-run@0.2.4 pins tmp@0.2.5; no newer web-ext-run release available.
-  web-ext-run>tmp: ">=0.2.6"
-  # GHSA-gv7w-rqvm-qjhr / GHSA-g7r4-m6w7-qqqr: esbuild RCE via Deno binary
-  # integrity bypass and arbitrary file read on Windows dev server.
-  esbuild: ">=0.28.1"
-  # CVE-2026-6734, CVE-2026-9697 (HIGH), CVE-2026-9679, CVE-2026-9678
-  # (MEDIUM), CVE-2026-11525, CVE-2026-6733 (LOW): undici vulnerabilities
-  # in versions < 7.28.0. Transitive dep via @semantic-release/github.
-  undici: ">=7.28.0"
+    # node-notifier@10.0.1 (via wxt → web-ext-run) pins uuid@^8.3.2 which is
+    # vulnerable to GHSA-w5hq-g745-h8pq. Scoped to node-notifier only so the
+    # rest of the tree resolves its own preferred uuid version. node-notifier
+    # only calls uuid.v4(), API-compatible across all major versions.
+    node-notifier>uuid: '>=11.1.1'
+    # GHSA-w7jw-789q-3m8p: shell-quote quote() newline escaping in .op values.
+    # fx-runner@1.4.0 pins shell-quote@1.7.3; fx-runner@1.5.0 already uses 1.8.4
+    # but web-ext-run@0.2.4 (no newer release) still depends on fx-runner@1.4.0.
+    fx-runner>shell-quote: '>=1.8.4'
+    # GHSA-ph9p-34f9-6g65: tmp path traversal via unsanitized prefix/postfix.
+    # web-ext-run@0.2.4 pins tmp@0.2.5; no newer web-ext-run release available.
+    web-ext-run>tmp: '>=0.2.6'
+    # GHSA-gv7w-rqvm-qjhr / GHSA-g7r4-m6w7-qqqr: esbuild RCE via Deno binary
+    # integrity bypass and arbitrary file read on Windows dev server.
+    esbuild: '>=0.28.1'
+    # CVE-2026-6734, CVE-2026-9697 (HIGH), CVE-2026-9679, CVE-2026-9678
+    # (MEDIUM), CVE-2026-11525, CVE-2026-6733 (LOW): undici vulnerabilities
+    # in versions < 7.28.0. Transitive dep via @semantic-release/github.
+    undici: '>=7.28.0'
 
 packageExtensions:
-  "minimatch@10.2.5":
-    dependencies:
-      brace-expansion: "^5.0.6"
+    'minimatch@10.2.5':
+        dependencies:
+            brace-expansion: '^5.0.6'

--- a/scripts/email-templates/mini-mealie-release.html
+++ b/scripts/email-templates/mini-mealie-release.html
@@ -1,1 +1,333 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html dir="ltr" lang="en"><head><link rel="preload" as="image" href="https://mini-mealie.shaplabs.org/48.png"/><meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/><meta name="x-apple-disable-message-reformatting"/></head><body style="background-color:#f6f6f6;font-family:&quot;Inter&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif"><!--$--><div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0" data-skip-in-text="true">Mini Mealie {{TAG}} Released - See what&#x27;s new<div> ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿</div></div><table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="max-width:100%;width:680px;margin:0 auto;background-color:#ffffff;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.05);overflow:hidden"><tbody><tr style="width:100%"><td><table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="display:flex;flex-direction:row;align-items:center;background-color:#e67e19;color:#ffffff;padding:24px 30px"><tbody><tr><td><table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation"><tbody style="width:100%"><tr style="width:100%"><td data-id="__react-email-column" style="padding-right:12px"><h1 style="margin:0;font-size:22px;line-height:28px;font-weight:700;color:#ffffff">Mini Mealie {{TAG}} Released</h1><p style="font-size:15px;line-height:22px;margin:6px 0 0;color:#ffeede;margin-top:6px;margin-right:0;margin-bottom:0;margin-left:0">Explore the latest updates and improvements</p></td><td data-id="__react-email-column" style="text-align:right"><img alt="Mini Mealie Logo" height="48" src="https://mini-mealie.shaplabs.org/48.png" style="display:inline-block;outline:none;border:none;text-decoration:none;vertical-align:middle;border-radius:6px" width="48"/></td></tr></tbody></table></td></tr></tbody></table><table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="padding:30px"><tbody><tr><td><h2 style="margin:0 0 16px;font-size:20px;line-height:28px;font-weight:600;color:#1f2937">What’s new in this release</h2>{{ITEMS}}<hr style="width:100%;border:none;border-top:1px solid #e5e7eb;margin:28px 0"/><p style="font-size:15px;line-height:24px;color:#374151;margin:0 0 12px;margin-top:0;margin-right:0;margin-bottom:12px;margin-left:0">Want to contribute or request a feature?</p><ul style="padding-left:20px;list-style-type:none"><li><a href="https://github.com/mrshappy0/mini-mealie/issues" style="color:#e67e19;text-decoration-line:none;text-decoration:none;font-weight:500" target="_blank">Report issues →</a></li><li><a href="https://github.com/mrshappy0/mini-mealie/discussions" style="color:#e67e19;text-decoration-line:none;text-decoration:none;font-weight:500" target="_blank">Join discussions →</a></li><li><a href="https://github.com/mrshappy0/mini-mealie/pulls" style="color:#e67e19;text-decoration-line:none;text-decoration:none;font-weight:500" target="_blank">Contribute via pull request →</a></li></ul><table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="margin-top:24px;text-align:center"><tbody><tr><td><a href="https://chromewebstore.google.com/detail/mini-mealie/lchfnbjpjoeejalacnpjnafenacmdocc" style="color:#ffffff;text-decoration-line:none;background-color:#e67e19;font-size:16px;font-weight:600;padding:12px 24px;border-radius:6px;text-decoration:none;display:inline-block" target="_blank">View in Chrome Web Store →</a></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table><table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="width:680px;max-width:100%;margin:32px auto 0 auto;padding:0 30px 30px;text-align:center"><tbody><tr><td><p style="font-size:12px;line-height:18px;color:#9ca3af;margin-top:16px;margin-bottom:16px">You’re receiving this email because you opted in for Mini Mealie release updates.</p><a href="{{{RESEND_UNSUBSCRIBE_URL}}}" style="color:#E86A33;text-decoration-line:none;display:inline-block;font-size:12px;text-decoration:underline;margin-top:6px" target="_blank">Unsubscribe</a><hr style="width:100%;border:none;border-top:1px solid #e5e7eb;margin:28px 0;border-color:#d1d5db"/><p style="font-size:12px;line-height:24px;color:#6b7280;margin-top:8px;margin-bottom:16px">Mini Mealie, powered by ShapLabs — Colorado, USA</p></td></tr></tbody></table><!--7--><!--/$--></body></html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+    <head>
+        <link rel="preload" as="image" href="https://mini-mealie.shaplabs.org/48.png" />
+        <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+        <meta name="x-apple-disable-message-reformatting" />
+    </head>
+    <body
+        style="
+            background-color: #f6f6f6;
+            font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        "
+    >
+        <!--$-->
+        <div
+            style="
+                display: none;
+                overflow: hidden;
+                line-height: 1px;
+                opacity: 0;
+                max-height: 0;
+                max-width: 0;
+            "
+            data-skip-in-text="true"
+        >
+            Mini Mealie {{TAG}} Released - See what&#x27;s new
+            <div>
+                 ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+            </div>
+        </div>
+        <table
+            align="center"
+            width="100%"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="
+                max-width: 100%;
+                width: 680px;
+                margin: 0 auto;
+                background-color: #ffffff;
+                border-radius: 12px;
+                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+                overflow: hidden;
+            "
+        >
+            <tbody>
+                <tr style="width: 100%">
+                    <td>
+                        <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="
+                                display: flex;
+                                flex-direction: row;
+                                align-items: center;
+                                background-color: #e67e19;
+                                color: #ffffff;
+                                padding: 24px 30px;
+                            "
+                        >
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <table
+                                            align="center"
+                                            width="100%"
+                                            border="0"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            role="presentation"
+                                        >
+                                            <tbody style="width: 100%">
+                                                <tr style="width: 100%">
+                                                    <td
+                                                        data-id="__react-email-column"
+                                                        style="padding-right: 12px"
+                                                    >
+                                                        <h1
+                                                            style="
+                                                                margin: 0;
+                                                                font-size: 22px;
+                                                                line-height: 28px;
+                                                                font-weight: 700;
+                                                                color: #ffffff;
+                                                            "
+                                                        >
+                                                            Mini Mealie {{TAG}} Released
+                                                        </h1>
+                                                        <p
+                                                            style="
+                                                                font-size: 15px;
+                                                                line-height: 22px;
+                                                                margin: 6px 0 0;
+                                                                color: #ffeede;
+                                                                margin-top: 6px;
+                                                                margin-right: 0;
+                                                                margin-bottom: 0;
+                                                                margin-left: 0;
+                                                            "
+                                                        >
+                                                            Explore the latest updates and
+                                                            improvements
+                                                        </p>
+                                                    </td>
+                                                    <td
+                                                        data-id="__react-email-column"
+                                                        style="text-align: right"
+                                                    >
+                                                        <img
+                                                            alt="Mini Mealie Logo"
+                                                            height="48"
+                                                            src="https://mini-mealie.shaplabs.org/48.png"
+                                                            style="
+                                                                display: inline-block;
+                                                                outline: none;
+                                                                border: none;
+                                                                text-decoration: none;
+                                                                vertical-align: middle;
+                                                                border-radius: 6px;
+                                                            "
+                                                            width="48"
+                                                        />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="padding: 30px"
+                        >
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <h2
+                                            style="
+                                                margin: 0 0 16px;
+                                                font-size: 20px;
+                                                line-height: 28px;
+                                                font-weight: 600;
+                                                color: #1f2937;
+                                            "
+                                        >
+                                            What’s new in this release
+                                        </h2>
+                                        {{ITEMS}}
+                                        <hr
+                                            style="
+                                                width: 100%;
+                                                border: none;
+                                                border-top: 1px solid #e5e7eb;
+                                                margin: 28px 0;
+                                            "
+                                        />
+                                        <p
+                                            style="
+                                                font-size: 15px;
+                                                line-height: 24px;
+                                                color: #374151;
+                                                margin: 0 0 12px;
+                                                margin-top: 0;
+                                                margin-right: 0;
+                                                margin-bottom: 12px;
+                                                margin-left: 0;
+                                            "
+                                        >
+                                            Want to contribute or request a feature?
+                                        </p>
+                                        <ul style="padding-left: 20px; list-style-type: none">
+                                            <li>
+                                                <a
+                                                    href="https://github.com/mrshappy0/mini-mealie/issues"
+                                                    style="
+                                                        color: #e67e19;
+                                                        text-decoration-line: none;
+                                                        text-decoration: none;
+                                                        font-weight: 500;
+                                                    "
+                                                    target="_blank"
+                                                    >Report issues →</a
+                                                >
+                                            </li>
+                                            <li>
+                                                <a
+                                                    href="https://github.com/mrshappy0/mini-mealie/discussions"
+                                                    style="
+                                                        color: #e67e19;
+                                                        text-decoration-line: none;
+                                                        text-decoration: none;
+                                                        font-weight: 500;
+                                                    "
+                                                    target="_blank"
+                                                    >Join discussions →</a
+                                                >
+                                            </li>
+                                            <li>
+                                                <a
+                                                    href="https://github.com/mrshappy0/mini-mealie/pulls"
+                                                    style="
+                                                        color: #e67e19;
+                                                        text-decoration-line: none;
+                                                        text-decoration: none;
+                                                        font-weight: 500;
+                                                    "
+                                                    target="_blank"
+                                                    >Contribute via pull request →</a
+                                                >
+                                            </li>
+                                        </ul>
+                                        <table
+                                            align="center"
+                                            width="100%"
+                                            border="0"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            role="presentation"
+                                            style="margin-top: 24px; text-align: center"
+                                        >
+                                            <tbody>
+                                                <tr>
+                                                    <td>
+                                                        <a
+                                                            href="https://chromewebstore.google.com/detail/mini-mealie/lchfnbjpjoeejalacnpjnafenacmdocc"
+                                                            style="
+                                                                color: #ffffff;
+                                                                text-decoration-line: none;
+                                                                background-color: #e67e19;
+                                                                font-size: 16px;
+                                                                font-weight: 600;
+                                                                padding: 12px 24px;
+                                                                border-radius: 6px;
+                                                                text-decoration: none;
+                                                                display: inline-block;
+                                                            "
+                                                            target="_blank"
+                                                            >View in Chrome Web Store →</a
+                                                        >
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table
+            align="center"
+            width="100%"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="
+                width: 680px;
+                max-width: 100%;
+                margin: 32px auto 0 auto;
+                padding: 0 30px 30px;
+                text-align: center;
+            "
+        >
+            <tbody>
+                <tr>
+                    <td>
+                        <p
+                            style="
+                                font-size: 12px;
+                                line-height: 18px;
+                                color: #9ca3af;
+                                margin-top: 16px;
+                                margin-bottom: 16px;
+                            "
+                        >
+                            You’re receiving this email because you opted in for Mini Mealie release
+                            updates.
+                        </p>
+                        <a
+                            href="{{{RESEND_UNSUBSCRIBE_URL}}}"
+                            style="
+                                color: #e86a33;
+                                text-decoration-line: none;
+                                display: inline-block;
+                                font-size: 12px;
+                                text-decoration: underline;
+                                margin-top: 6px;
+                            "
+                            target="_blank"
+                            >Unsubscribe</a
+                        >
+                        <hr
+                            style="
+                                width: 100%;
+                                border: none;
+                                border-top: 1px solid #e5e7eb;
+                                margin: 28px 0;
+                                border-color: #d1d5db;
+                            "
+                        />
+                        <p
+                            style="
+                                font-size: 12px;
+                                line-height: 24px;
+                                color: #6b7280;
+                                margin-top: 8px;
+                                margin-bottom: 16px;
+                            "
+                        >
+                            Mini Mealie, powered by ShapLabs — Colorado, USA
+                        </p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <!--7--><!--/$-->
+    </body>
+</html>

--- a/utils/tests/activity.test.ts
+++ b/utils/tests/activity.test.ts
@@ -246,8 +246,7 @@ describe('activity', () => {
     describe('multiple concurrent activities', () => {
         it('should track multiple activities and decrement count', async () => {
             const initialState = storageData[ACTIVITY_STORAGE_KEY] as
-                | { activeCount: number }
-                | undefined;
+                { activeCount: number } | undefined;
             const initialCount = initialState?.activeCount ?? 0;
 
             await beginActivity('Activity A');


### PR DESCRIPTION
Combines four dependabot PRs into one:

- **resend** 6.12.4 → 6.16.0 (#152)
- **eslint** 10.5.0 → 10.6.0 (#153)
- **globals** 17.6.0 → 17.7.0 (#154)
- **prettier** 3.8.4 → 3.9.4 (#155)

## Prettier 3.9.x formatting changes

Prettier 3.9 introduces major parser upgrades (Markdown micromark v4, YAML yaml v2, GraphQL v17). This reformats:
- YAML files — 2-space → 4-space indentation (matching `.prettierrc` `tabWidth: 4`)
- HTML templates — proper pretty-printing instead of minified single-line
- TypeScript union types — minor reformatting
- All changes are **whitespace-only**

## Verified locally

- `pnpm prettier --check .` ✓
- `pnpm lint` (eslint) ✓
- `pnpm compile` (tsc) ✓
- `pnpm test run` — all 194 tests pass ✓

Closes #152, closes #153, closes #154, closes #155.