### PR TITLE
fix(firefox): use callback-compatible executeScript in getPageHTML

### DIFF
--- a/utils/invoke.ts
+++ b/utils/invoke.ts
@@ -244,14 +244,39 @@ async function maybeOpenRecipeAfterImport(
 
 async function getPageHTML(tabId: number) {
     try {
-        const results = await chrome.scripting.executeScript<[], string>({
-            target: { tabId },
-            func: () => document.documentElement.outerHTML,
-        });
+        // Firefox's chrome.* namespace is callback-only (calling without a callback
+        // returns undefined instead of a Promise), while Chrome returns a Promise.
+        // Support both, mirroring the tabs.query shim in storage.ts.
+        const results = await new Promise<chrome.scripting.InjectionResult<string>[]>(
+            (resolve, reject) => {
+                const result = chrome.scripting.executeScript<[], string>(
+                    {
+                        target: { tabId },
+                        func: () => document.documentElement.outerHTML,
+                    },
+                    (callbackResults) => {
+                        if (chrome.runtime.lastError) {
+                            reject(new Error(chrome.runtime.lastError.message));
+                            return;
+                        }
+                        resolve(callbackResults);
+                    },
+                ) as unknown;
+                if (result instanceof Promise) void result.then(resolve, reject);
+            },
+        );
 
         const html = results[0]?.result;
         return typeof html === 'string' ? html : null;
-    } catch {
+    } catch (error) {
+        void logEvent({
+            level: 'warn',
+            feature: 'html-capture',
+            action: 'getPageHTML',
+            phase: 'failure',
+            message: 'executeScript failed',
+            data: { error: error instanceof Error ? error.message : String(error) },
+        });
         return null;
     }
 }

--- a/utils/tests/network.test.ts
+++ b/utils/tests/network.test.ts
@@ -585,6 +585,71 @@ describe('runCreateRecipe', () => {
         expect(createRecipeFromURL).not.toHaveBeenCalled();
     });
 
+    it('should call createRecipeFromHTML when executeScript is callback-only (Firefox)', async () => {
+        mockConfig.createRecipeFromHTMLResult = { slug: 'test-slug' };
+
+        // Firefox's chrome.* namespace ignores the callback-based invocation's
+        // return value (undefined, not a Promise) and instead resolves via the
+        // callback argument.
+        chrome.scripting.executeScript = vi.fn().mockImplementation((_opts, callback) => {
+            callback?.([{ result: mockHtml }]);
+            return undefined;
+        });
+
+        chrome.storage.sync.get = vi.fn().mockImplementation((_keys, callback) =>
+            callback({
+                mealieServer: mockServer,
+                mealieApiToken: mockToken,
+                recipeCreateMode: RecipeCreateMode.HTML,
+            }),
+        );
+
+        runCreateRecipe({ id: mockTabId, url: mockUrl } as chrome.tabs.Tab);
+        await flushPromises();
+
+        const { createRecipeFromHTML } = await import('../network');
+        expect(createRecipeFromHTML).toHaveBeenCalledWith(
+            mockHtml,
+            mockServer,
+            mockToken,
+            mockUrl,
+            true,
+            true,
+        );
+    });
+
+    it('should show ❌ badge when callback-only executeScript reports lastError', async () => {
+        chrome.scripting.executeScript = vi.fn().mockImplementation((_opts, callback) => {
+            Object.defineProperty(chrome.runtime, 'lastError', {
+                value: { message: 'Missing host permission for the tab' },
+                configurable: true,
+                writable: true,
+            });
+            callback?.(undefined);
+            Object.defineProperty(chrome.runtime, 'lastError', {
+                value: undefined,
+                configurable: true,
+                writable: true,
+            });
+            return undefined;
+        });
+
+        chrome.storage.sync.get = vi.fn().mockImplementation((_keys, callback) =>
+            callback({
+                mealieServer: mockServer,
+                mealieApiToken: mockToken,
+                recipeCreateMode: RecipeCreateMode.HTML,
+            }),
+        );
+
+        runCreateRecipe({ id: mockTabId, url: mockUrl } as chrome.tabs.Tab);
+        await flushPromises();
+
+        const { createRecipeFromHTML } = await import('../network');
+        expect(createRecipeFromHTML).not.toHaveBeenCalled();
+        expect(showBadge).toHaveBeenCalledWith('❌', 4);
+    });
+
     it('should return failure if fetch response is not ok', async () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
             // Intentionally empty: this test exercises an error path.


### PR DESCRIPTION
## Summary

HTML-mode recipe import has never worked on Firefox — right-click →
"Create Recipe from HTML" silently fails with "Failed to capture page
HTML" on every page.

`chrome.scripting.executeScript()` returns a Promise in Chrome, but in
Firefox the `chrome.*` namespace is callback-only: calling it without a
callback returns `undefined` instead of a Promise. `getPageHTML` in
`utils/invoke.ts` was awaiting that `undefined`, so `results[0]` threw,
and the bare `catch {}` swallowed the error and returned `null` with no
diagnostic.

This is the same class of issue already fixed for `chrome.storage.sync.get`
and `chrome.tabs.query` in #90 — `executeScript` was just missed.

## Fix

- Wrap `chrome.scripting.executeScript` in a promise/callback shim
  (same idiom as the existing `tabs.query` shim in `storage.ts`), so it
  works whether the browser returns a Promise (Chrome) or only invokes
  the callback (Firefox).
- Log the caught error's actual message instead of swallowing it, so
  future Firefox-only failures show up in Activity Logs with a reason.

## Test plan

- [x] `pnpm compile`, `pnpm lint`, `pnpm test` all pass (196/196 tests,
      including two new regression tests for the callback-only path and
      the `lastError` failure path)
- [x] Verified with a minimal probe extension in headless Firefox 152 —
      confirmed `chrome.scripting.executeScript` returns `undefined`
      pre-fix and works correctly post-fix
- [x] Manually tested via a temporary add-on load in real Firefox 152
      (`about:debugging`) against `pnpm build:firefox`: HTML-mode import
      on an AllRecipes page now succeeds end-to-end and the recipe lands
      in Mealie