### PR TITLE
ci(e2e): add scheduled Mealie + Firefox latest canary

### DIFF
--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -6,9 +6,15 @@ name: E2E Canary (latest upstream deps)
 # is a heads-up, not a merge block.
 #
 # One matrix leg per moving dependency, holding the others pinned, so a red leg names the culprit
-# (an "all latest at once" run couldn't tell you whether Mealie or Firefox broke). Chromium is not
-# a leg — it's frozen inside the Playwright dep, so a new Chromium only lands via a dependabot
-# Playwright bump, which the normal PR gate already tests.
+# (an "all latest at once" run couldn't tell you whether Mealie or Firefox broke).
+#
+# Chromium has no leg by deliberate tradeoff: Mealie/Firefox are proactive weekly checks against
+# upstream latest; Chromium only moves via a Dependabot Playwright bump (reactive, can lag real
+# Chrome). Playwright/Chromium has been stabler here than Gecko — revisit with a chromium-latest
+# leg if that gap starts to matter.
+#
+# The firefox-latest leg sets firefox_version so e2e.yml skips its chrome job (Chrome ignores
+# FIREFOX_VER and would only re-run the pinned PR-gate Chrome suite).
 #
 # Note: `schedule` only fires from the repository's default branch. Until this is on the default
 # branch, run it manually via "Run workflow" (workflow_dispatch).

--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -1,0 +1,46 @@
+name: E2E Canary (latest upstream deps)
+
+# Early-warning canary: runs the full E2E suite against the *latest* of each externally-released
+# dependency we fetch at runtime — Mealie and Firefox — on a schedule, so upstream releases that
+# break the extension surface here BEFORE they reach the pinned PR gate. Non-blocking: a red run
+# is a heads-up, not a merge block.
+#
+# One matrix leg per moving dependency, holding the others pinned, so a red leg names the culprit
+# (an "all latest at once" run couldn't tell you whether Mealie or Firefox broke). Chromium is not
+# a leg — it's frozen inside the Playwright dep, so a new Chromium only lands via a dependabot
+# Playwright bump, which the normal PR gate already tests.
+#
+# Note: `schedule` only fires from the repository's default branch. Until this is on the default
+# branch, run it manually via "Run workflow" (workflow_dispatch).
+
+on:
+    schedule:
+        # Weekly, Mondays 06:00 UTC. Mealie and Firefox release roughly monthly, so weekly is
+        # plenty; bump to a daily cron if you want faster signal.
+        - cron: '0 6 * * 1'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    canary:
+        name: ${{ matrix.name }}
+        strategy:
+            # Don't let one red leg cancel the other — we want signal from both.
+            fail-fast: false
+            matrix:
+                include:
+                    # Mealie :latest, Firefox pinned.
+                    - name: mealie-latest
+                      mealie_image: ghcr.io/mealie-recipes/mealie:latest
+                      firefox_version: ''
+                    # Firefox latest, Mealie pinned. (Also surfaces geckodriver/Firefox
+                    # incompatibilities, since a newer Firefox is what breaks the pinned driver.)
+                    - name: firefox-latest
+                      mealie_image: ''
+                      firefox_version: latest
+        uses: ./.github/workflows/e2e.yml
+        with:
+            mealie_image: ${{ matrix.mealie_image }}
+            firefox_version: ${{ matrix.firefox_version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,9 +9,27 @@ on:
         branches:
             - main
     workflow_dispatch:
+    # Callable by e2e-canary.yml to run the same jobs against newer upstream deps.
+    workflow_call:
+        inputs:
+            mealie_image:
+                description: 'Mealie image to test against (empty → the pinned version in mealie.e2e.yml)'
+                type: string
+                required: false
+            firefox_version:
+                description: 'Firefox version for setup.sh (empty → the pinned FIREFOX_VER; "latest" for newest)'
+                type: string
+                required: false
 
 permissions:
     contents: read
+
+env:
+    # Empty on pull_request / workflow_dispatch, so the harness falls back to the pinned
+    # defaults (Mealie v3.20.1 in mealie.e2e.yml, Firefox 142.0 in setup.sh). The canary sets
+    # exactly one of these per matrix leg to isolate which upstream dep broke.
+    MEALIE_IMAGE: ${{ inputs.mealie_image }}
+    FIREFOX_VER: ${{ inputs.firefox_version }}
 
 jobs:
     chrome:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,10 @@ env:
 jobs:
     chrome:
         name: Chrome MV3
+        # Skip on the canary's firefox-latest leg: Chrome never reads FIREFOX_VER, so that run
+        # would be identical to the pinned PR-gate Chrome job (wasted CI, no new signal).
+        # Empty/unset on pull_request and on mealie-latest → Chrome still runs.
+        if: ${{ !inputs.firefox_version }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code

--- a/docs/developers-guide/e2e-testing.md
+++ b/docs/developers-guide/e2e-testing.md
@@ -100,8 +100,28 @@ pnpm test:e2e:down
 - No secrets: Mealie is ephemeral and the API token is minted at runtime.
 - Fully hermetic: the default recipe is the local fixture, so no third-party site can flake CI.
 - Chrome uses the self-contained `pnpm test:e2e`; Firefox adds the `setup.sh` step.
-- **Pinned Mealie** (`v3.20.1`) so the gate is deterministic — a red PR means *your* change broke,
-  not that Mealie shipped a new release.
+- **Everything pinned** so the gate is deterministic — a red PR means *your* change broke, not
+  that an upstream dep shipped a release: Mealie (`v3.20.1`), Firefox (`142.0`), geckodriver
+  (`v0.36.0`), and Chromium (frozen inside the Playwright dep).
+
+## Canary (early warning)
+
+`.github/workflows/e2e-canary.yml` runs the same suite weekly (and on demand) against the
+**latest** of the dependencies we fetch at runtime, so upstream releases that break the extension
+surface *here* before they reach the pinned PR gate. It's **non-blocking** — a heads-up, not a
+merge gate — and reuses `e2e.yml` via `workflow_call`.
+
+It's a **matrix with one leg per moving dependency**, each holding the others pinned so a red leg
+names the culprit:
+
+| Leg | Overrides | Pinned |
+| --- | --- | --- |
+| `mealie-latest` | Mealie → `:latest` | Firefox `142.0` |
+| `firefox-latest` | Firefox → `latest` (also catches geckodriver/Firefox skew) | Mealie `v3.20.1` |
+
+Chromium has no leg: it's frozen in the Playwright dependency, so a new Chromium only arrives via
+a dependabot Playwright bump — which the normal PR gate already tests. `schedule` only fires from
+the default branch; trigger it manually with "Run workflow" otherwise.
 
 To run on your own server instead of GitHub-hosted, change `runs-on` to `[self-hosted]` —
 just ensure Docker is installed and the runner user is in the `docker` group. The harnesses

--- a/docs/developers-guide/e2e-testing.md
+++ b/docs/developers-guide/e2e-testing.md
@@ -114,15 +114,27 @@ merge gate — and reuses `e2e.yml` via `workflow_call`.
 It's a **matrix with one leg per moving dependency**, each holding the others pinned so a red leg
 names the culprit:
 
-| Leg | Overrides | Pinned |
-| --- | --- | --- |
-| `mealie-latest` | Mealie → `:latest` | Firefox `142.0` |
-| `firefox-latest` | Firefox → `latest` (also catches geckodriver/Firefox skew) | Mealie `v3.20.1` |
+| Leg | Overrides | Pinned | Jobs |
+| --- | --- | --- | --- |
+| `mealie-latest` | Mealie → `:latest` | Firefox `142.0` | Chrome + Firefox |
+| `firefox-latest` | Firefox → `latest` (also catches geckodriver/Firefox skew) | Mealie `v3.20.1` | Firefox only |
 
-Chromium has no leg: it's frozen in the Playwright dependency, so a new Chromium only arrives via
-a dependabot Playwright bump — which the normal PR gate already tests. `schedule` only fires from
-the default branch; trigger it manually with "Run workflow" otherwise.
+Chromium has no canary leg **by deliberate tradeoff**. Mealie/Firefox legs are *proactive*
+(weekly against real upstream `latest`). Chromium coverage stays *reactive*: a new Chromium only
+arrives via a Dependabot Playwright bump, which the PR gate then tests — and that can lag real
+Chrome stable. Playwright/Chromium has historically been stabler here than Gecko, so we accept
+weaker early warning on the primary browser for now; see
+[#183](https://github.com/mrshappy0/mini-mealie/issues/183) for a possible future
+`chromium-latest` leg if that gap starts to hurt. `schedule` only fires from the default
+branch; trigger the canary manually with "Run workflow" otherwise.
+
+The `firefox-latest` leg runs **only** the Firefox job (Chrome would ignore `FIREFOX_VER` and
+duplicate the pinned PR-gate Chrome run). The `mealie-latest` leg still runs both browsers.
 
 To run on your own server instead of GitHub-hosted, change `runs-on` to `[self-hosted]` —
-just ensure Docker is installed and the runner user is in the `docker` group. The harnesses
-stay excluded from lint / tsc / vitest and from the AMO sources zip.
+just ensure Docker is installed and the runner user is in the `docker` group. On a persistent
+runner, "latest" can go stale without care: Firefox is cached under a **version-keyed** directory
+(`~/.local/firefox-nonsnap-$FIREFOX_VER`), and `FIREFOX_VER=latest` always re-downloads; Mealie
+`compose up` **pulls** when `MEALIE_IMAGE` is set (the canary override) so `:latest` is refreshed.
+GitHub-hosted `ubuntu-latest` is a fresh VM each run, so this only matters for self-hosted.
+The harnesses stay excluded from lint / tsc / vitest and from the AMO sources zip.

--- a/e2e-geckodriver/firefox-e2e.ts
+++ b/e2e-geckodriver/firefox-e2e.ts
@@ -35,8 +35,12 @@ import { waitForRecipe } from '../e2e-shared/mealie-api';
 loadE2eEnv();
 
 const HOME = os.homedir();
+// Must match e2e-geckodriver/setup.sh's version-keyed default
+// (~/.local/firefox-nonsnap-$FIREFOX_VER). Override with E2E_FIREFOX_BIN if needed.
+const FIREFOX_VER = process.env.FIREFOX_VER?.trim() || '142.0';
 const FIREFOX_BIN =
-    process.env.E2E_FIREFOX_BIN?.trim() || path.join(HOME, '.local/firefox-nonsnap/firefox/firefox');
+    process.env.E2E_FIREFOX_BIN?.trim() ||
+    path.join(HOME, `.local/firefox-nonsnap-${FIREFOX_VER}`, 'firefox', 'firefox');
 const GECKODRIVER_BIN =
     process.env.E2E_GECKODRIVER_BIN?.trim() || path.join(HOME, '.local/bin/geckodriver');
 

--- a/e2e-geckodriver/setup.sh
+++ b/e2e-geckodriver/setup.sh
@@ -10,7 +10,9 @@ GECKO_VER=${GECKO_VER:-v0.36.0}
 # Pin Firefox so the PR gate is deterministic (a red run means your change broke, not that
 # Firefox shipped a release). The canary sets FIREFOX_VER=latest for early-warning signal.
 FIREFOX_VER=${FIREFOX_VER:-142.0}
-FIREFOX_DIR=${FIREFOX_DIR:-$HOME/.local/firefox-nonsnap}
+# Version-keyed cache dir so pinned and canary installs don't clobber each other on a
+# persistent (self-hosted) runner. Override with FIREFOX_DIR if you need a fixed path.
+FIREFOX_DIR=${FIREFOX_DIR:-$HOME/.local/firefox-nonsnap-$FIREFOX_VER}
 GECKO_BIN=${GECKO_BIN:-$HOME/.local/bin/geckodriver}
 
 # Single cleanup trap for any temp dirs the blocks below create (guarded for `set -u`).
@@ -26,6 +28,12 @@ if [[ ! -x "$GECKO_BIN" ]]; then
     install -m 0755 "$tmp/geckodriver" "$GECKO_BIN"
 fi
 "$GECKO_BIN" --version | head -1
+
+# `latest` must re-download every run — a version-keyed dir named "latest" would otherwise
+# freeze the first resolved binary forever on a self-hosted runner.
+if [[ "$FIREFOX_VER" == "latest" ]]; then
+    rm -rf "$FIREFOX_DIR"
+fi
 
 if [[ ! -x "$FIREFOX_DIR/firefox/firefox" ]]; then
     echo "[setup] downloading non-snap Firefox $FIREFOX_VER -> $FIREFOX_DIR"

--- a/e2e-shared/mealie-docker.ts
+++ b/e2e-shared/mealie-docker.ts
@@ -74,6 +74,12 @@ export type MealieHandle = { server: string; token: string };
 
 /** Start Mealie (if not already up), wait for health, mint a fresh API token. */
 export async function mealieUp(): Promise<MealieHandle> {
+    // When MEALIE_IMAGE is set (canary mealie-latest), re-pull so a self-hosted runner
+    // doesn't keep a stale `:latest` (compose up alone won't refresh an existing local tag).
+    // PR-gate runs leave MEALIE_IMAGE unset and use the pinned image — no pull needed.
+    if (process.env.MEALIE_IMAGE?.trim()) {
+        compose(['pull']);
+    }
     compose(['up', '-d']);
     await waitForHealthy();
     const accessToken = await login();


### PR DESCRIPTION
## Summary
- Adds a non-blocking weekly (and manual) E2E canary that tests against the latest Mealie image and the latest Firefox, so upstream releases show up here before they hit the pinned PR gate.
- Makes `e2e.yml` reusable (`workflow_call`) with optional `mealie_image` / `firefox_version` inputs, wired to `MEALIE_IMAGE` / `FIREFOX_VER`. Empty on normal PRs, so the gate keeps the pinned defaults.
- Matrix has one leg per moving dependency (`mealie-latest`, `firefox-latest`), each holding the other pinned, so a red leg names the culprit. Chromium stays out — it only moves with Playwright via Dependabot, which the PR gate already covers.

## Why
The PR gate pins Mealie and Firefox on purpose (a red PR should mean *your* change broke). Without a canary, a Mealie or Firefox release that breaks the extension only shows up after someone bumps the pin. This is early warning only — it does not block merges.

## Test plan
- [ ] CI on this PR: normal `E2E` workflow still runs with pinned Mealie/Firefox (empty inputs → defaults)
- [ ] After merge (or via "Run workflow" on this branch if enabled): trigger **E2E Canary** manually
- [ ] Confirm both matrix legs start (`mealie-latest`, `firefox-latest`) with `fail-fast: false`
- [ ] Confirm `mealie-latest` pulls `ghcr.io/mealie-recipes/mealie:latest` and leaves Firefox pinned
- [ ] Confirm `firefox-latest` sets `FIREFOX_VER=latest` and leaves Mealie pinned
- [ ] Note: first `firefox-latest` run may go red — pin is Firefox `142.0` while current latest is ~152; that is useful signal, not a setup bug