### PR TITLE
fix(deps): override fast-uri >=3.1.4 for GHSA-v2hh-gcrm-f6hx

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   esbuild: '>=0.28.1'
   firefox-profile>adm-zip: '>=0.6.0'
   undici: '>=7.28.0'
+  fast-uri: '>=3.1.4'
 
 packageExtensionsChecksum: sha256-xx97ir72Z/Od9tONlIEsbEVKGUrhc6tGfUeweqcsMOk=
 
@@ -1955,8 +1956,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -5275,7 +5276,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6202,7 +6203,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@4.1.1: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,10 @@ overrides:
     # (MEDIUM), CVE-2026-11525, CVE-2026-6733 (LOW): undici vulnerabilities
     # in versions < 7.28.0. Transitive dep via @semantic-release/github.
     undici: '>=7.28.0'
+    # GHSA-v2hh-gcrm-f6hx: fast-uri host confusion via literal backslash
+    # authority delimiter in versions <=3.1.3. Transitive via
+    # @commitlint → ajv (no newer commitlint pin yet).
+    fast-uri: '>=3.1.4'
 
 packageExtensions:
     'minimatch@10.2.5':


### PR DESCRIPTION
## Summary
- Nightly dependency audit failed on the same `fast-uri` advisory two nights in a row ([#184](https://github.com/mrshappy0/mini-mealie/issues/184), [#191](https://github.com/mrshappy0/mini-mealie/issues/191)).
- Add a `pnpm` override to `fast-uri >=3.1.4` (same pattern as existing transitive security pins in `pnpm-workspace.yaml`) and refresh the lockfile to `4.1.1`.
- Path is `commitlint → ajv → fast-uri` (dev tooling only).

## Test plan
- [x] `pnpm audit` reports no known vulnerabilities
- [ ] Scheduled Dependency Audit workflow passes (or run via workflow_dispatch)
- [ ] Close #184 and #191 after merge

Closes #184
Closes #191