### PR TITLE
fix(e2e): allow geckodriver system access for Firefox 153+

### DIFF
--- a/e2e-geckodriver/firefox-e2e.ts
+++ b/e2e-geckodriver/firefox-e2e.ts
@@ -61,7 +61,10 @@ async function buildDriver(): Promise<WebDriver> {
     options.setPreference('xpinstall.signatures.required', false);
     options.setPreference('extensions.langpacks.signatures.required', false);
 
-    const service = new ServiceBuilder(GECKODRIVER_BIN);
+    // Firefox 153+ blocks WebDriver navigation to moz-extension:// pages unless
+    // geckodriver opts into parent-process access. Harmless on older pins (142).
+    // https://firefox-source-docs.mozilla.org/testing/geckodriver/Flags.html#allow-system-access
+    const service = new ServiceBuilder(GECKODRIVER_BIN).addArguments('--allow-system-access');
     return new Builder().forBrowser('firefox').setFirefoxOptions(options).setFirefoxService(service).build();
 }
 


### PR DESCRIPTION
## Summary
- Passes geckodriver `--allow-system-access` so Firefox 153+ can open `moz-extension://` popup pages under Selenium.
- Without the flag, WebDriver `driver.get(popup)` fails on Firefox 153+; pinned older channels (e.g. 142) still work either way.
- Flag is documented as required for parent-process / extension-page access; safe on older Firefox pins.

## Context
Seen on the fork's `firefox-latest` canary (Firefox 153 refused popup navigation). Same failure mode applies whenever CI or local E2E uses a current Firefox + geckodriver against extension pages.

Docs: https://firefox-source-docs.mozilla.org/testing/geckodriver/Flags.html#allow-system-access

## Test plan
- [ ] PR E2E Firefox still green (pinned channel)
- [ ] Optional: run Firefox E2E against Firefox 153+ and confirm `driver.get(popup)` succeeds
- [ ] Chrome / other legs unchanged