### PR TITLE
ci(e2e): add chrome-latest canary via Chrome for Testing

### DIFF
--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -1,20 +1,21 @@
 name: E2E Canary (latest upstream deps)
 
 # Early-warning canary: runs the full E2E suite against the *latest* of each externally-released
-# dependency we fetch at runtime — Mealie and Firefox — on a schedule, so upstream releases that
-# break the extension surface here BEFORE they reach the pinned PR gate. Non-blocking: a red run
-# is a heads-up, not a merge block.
+# dependency we fetch at runtime — Mealie, Firefox, and Chrome for Testing — on a schedule, so
+# upstream releases that break the extension surface here BEFORE they reach the pinned PR gate.
+# Non-blocking: a red run is a heads-up, not a merge block.
 #
 # One matrix leg per moving dependency, holding the others pinned, so a red leg names the culprit
-# (an "all latest at once" run couldn't tell you whether Mealie or Firefox broke).
+# (an "all latest at once" run couldn't tell you whether Mealie, Firefox, or Chrome broke).
 #
-# Chromium has no leg by deliberate tradeoff: Mealie/Firefox are proactive weekly checks against
-# upstream latest; Chromium only moves via a Dependabot Playwright bump (reactive, can lag real
-# Chrome). Playwright/Chromium has been stabler here than Gecko — revisit with a chromium-latest
-# leg if that gap starts to matter.
+# chrome-latest keeps Playwright pinned and drives Chrome for Testing @latest via
+# PLAYWRIGHT_CHROME_EXECUTABLE (not branded Google Chrome — store Chrome removed side-load flags;
+# not `playwright install chromium@latest`, which fights Playwright's bundled-browser pairing).
+# A smoke step launches that binary with no extension first: smoke fail → Playwright↔CfT/tooling;
+# smoke pass + suite fail → product/Chrome-behavior.
 #
 # The firefox-latest leg sets firefox_version so e2e.yml skips its chrome job (Chrome ignores
-# FIREFOX_VER and would only re-run the pinned PR-gate Chrome suite).
+# FIREFOX_VER). The chrome-latest leg sets chrome_version so e2e.yml skips its firefox job.
 #
 # Note: `schedule` only fires from the repository's default branch. Until this is on the default
 # branch, run it manually via "Run workflow" (workflow_dispatch).
@@ -33,20 +34,28 @@ jobs:
     canary:
         name: ${{ matrix.name }}
         strategy:
-            # Don't let one red leg cancel the other — we want signal from both.
+            # Don't let one red leg cancel the others — we want signal from each.
             fail-fast: false
             matrix:
                 include:
-                    # Mealie :latest, Firefox pinned.
+                    # Mealie :latest, Firefox + Chromium pinned.
                     - name: mealie-latest
                       mealie_image: ghcr.io/mealie-recipes/mealie:latest
                       firefox_version: ''
-                    # Firefox latest, Mealie pinned. (Also surfaces geckodriver/Firefox
+                      chrome_version: ''
+                    # Firefox latest, Mealie + Chromium pinned. (Also surfaces geckodriver/Firefox
                     # incompatibilities, since a newer Firefox is what breaks the pinned driver.)
                     - name: firefox-latest
                       mealie_image: ''
                       firefox_version: latest
+                      chrome_version: ''
+                    # Chrome for Testing latest, Mealie + Firefox pinned. Playwright stays pinned.
+                    - name: chrome-latest
+                      mealie_image: ''
+                      firefox_version: ''
+                      chrome_version: latest
         uses: ./.github/workflows/e2e.yml
         with:
             mealie_image: ${{ matrix.mealie_image }}
             firefox_version: ${{ matrix.firefox_version }}
+            chrome_version: ${{ matrix.chrome_version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,23 +20,29 @@ on:
                 description: 'Firefox version for setup.sh (empty → the pinned FIREFOX_VER; "latest" for newest)'
                 type: string
                 required: false
+            chrome_version:
+                description: 'Chrome for Testing tag (empty → Playwright bundled Chromium; "latest" for CfT canary)'
+                type: string
+                required: false
 
 permissions:
     contents: read
 
 env:
     # Empty on pull_request / workflow_dispatch, so the harness falls back to the pinned
-    # defaults (Mealie v3.20.1 in mealie.e2e.yml, Firefox 142.0 in setup.sh). The canary sets
-    # exactly one of these per matrix leg to isolate which upstream dep broke.
+    # defaults (Mealie v3.20.1 in mealie.e2e.yml, Firefox 142.0 in setup.sh, Playwright's
+    # bundled Chromium). The canary sets exactly one of these per matrix leg to isolate which
+    # upstream dep broke.
     MEALIE_IMAGE: ${{ inputs.mealie_image }}
     FIREFOX_VER: ${{ inputs.firefox_version }}
+    CHROME_FOR_TESTING_TAG: ${{ inputs.chrome_version }}
 
 jobs:
     chrome:
         name: Chrome MV3
         # Skip on the canary's firefox-latest leg: Chrome never reads FIREFOX_VER, so that run
         # would be identical to the pinned PR-gate Chrome job (wasted CI, no new signal).
-        # Empty/unset on pull_request and on mealie-latest → Chrome still runs.
+        # Empty/unset on pull_request and on mealie-latest / chrome-latest → Chrome still runs.
         if: ${{ !inputs.firefox_version }}
         runs-on: ubuntu-latest
         steps:
@@ -58,8 +64,24 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
+            # PR gate / mealie-latest: Playwright's pinned Chromium. chrome-latest: Chrome for
+            # Testing @latest via executablePath (branded Google Chrome cannot side-load
+            # extensions; do not `playwright install chromium@latest` either — that fights the
+            # Playwright↔browser pairing).
             - name: Install Playwright Chromium
+              if: ${{ !inputs.chrome_version }}
               run: pnpm test:e2e:chromium:install
+
+            - name: Install Chrome for Testing
+              if: ${{ inputs.chrome_version == 'latest' }}
+              run: |
+                  pnpm exec playwright install-deps chromium
+                  pnpm test:e2e:chrome-cft:install
+
+            # Isolates Playwright↔CfT/tooling failures from product/Chrome-behavior failures.
+            - name: Smoke — launch Chrome for Testing under Playwright (no extension)
+              if: ${{ inputs.chrome_version == 'latest' }}
+              run: pnpm test:e2e:chrome-cft:smoke
 
             - name: Run Chrome E2E (Docker Mealie + build + spec + teardown)
               run: pnpm test:e2e
@@ -76,6 +98,9 @@ jobs:
 
     firefox:
         name: Firefox MV2
+        # Skip on the canary's chrome-latest leg: Firefox never reads CfT overrides,
+        # so that run would duplicate the pinned PR-gate Firefox job.
+        if: ${{ !inputs.chrome_version }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Code

--- a/docs/developers-guide/e2e-testing.md
+++ b/docs/developers-guide/e2e-testing.md
@@ -89,6 +89,8 @@ pnpm test:e2e:down
 | `MEALIE_IMAGE` / `MEALIE_PORT` | `…/mealie:v3.20.1` / `9925` | Docker Mealie image / host port |
 | `E2E_FIREFOX_XPI` | newest `.output/*-firefox.zip` | Firefox add-on to install |
 | `FIREFOX_VER` | `142.0` (pinned) | Firefox version `setup.sh` fetches; set `latest` for the canary |
+| `PLAYWRIGHT_CHROME_EXECUTABLE` | (unset → Playwright Chromium) | absolute path to Chrome for Testing (canary) |
+| `CHROME_FOR_TESTING_TAG` | `latest` | tag passed to `@puppeteer/browsers` (`latest`, `stable`, …) |
 | `E2E_HEADLESS` | on | set `0` to watch Firefox run |
 
 ## CI
@@ -116,25 +118,33 @@ names the culprit:
 
 | Leg | Overrides | Pinned | Jobs |
 | --- | --- | --- | --- |
-| `mealie-latest` | Mealie → `:latest` | Firefox `142.0` | Chrome + Firefox |
+| `mealie-latest` | Mealie → `:latest` | Firefox `142.0`, Playwright Chromium | Chrome + Firefox |
 | `firefox-latest` | Firefox → `latest` (also catches geckodriver/Firefox skew) | Mealie `v3.20.1` | Firefox only |
+| `chrome-latest` | Chrome for Testing → `latest` via `PLAYWRIGHT_CHROME_EXECUTABLE` | Mealie `v3.20.1`, Firefox `142.0`, Playwright version | Chrome only |
 
-Chromium has no canary leg **by deliberate tradeoff**. Mealie/Firefox legs are *proactive*
-(weekly against real upstream `latest`). Chromium coverage stays *reactive*: a new Chromium only
-arrives via a Dependabot Playwright bump, which the PR gate then tests — and that can lag real
-Chrome stable. Playwright/Chromium has historically been stabler here than Gecko, so we accept
-weaker early warning on the primary browser for now; see
-[#183](https://github.com/mrshappy0/mini-mealie/issues/183) for a possible future
-`chromium-latest` leg if that gap starts to hurt. `schedule` only fires from the default
-branch; trigger the canary manually with "Run workflow" otherwise.
+`chrome-latest` keeps Playwright pinned and downloads **Chrome for Testing** `@latest`
+(`pnpm test:e2e:chrome-cft:install`), then drives it with `executablePath`. Branded Google Chrome
+is not used — Google removed the flags needed to side-load unpacked extensions. Do **not** try
+`playwright install chromium@latest` either — that fights Playwright's bundled-browser pairing.
+
+Before the suite, a smoke step (`pnpm test:e2e:chrome-cft:smoke`) launches that binary with no
+extension: smoke fail → Playwright↔CfT/tooling (or install/path); smoke pass + suite fail →
+product / Chrome-behavior. A red leg is early warning and triage, not automatic proof that Chrome
+broke the extension. (Addresses
+[#183](https://github.com/mrshappy0/mini-mealie/issues/183).)
+
+`schedule` only fires from the default branch; trigger the canary manually with "Run workflow"
+otherwise.
 
 The `firefox-latest` leg runs **only** the Firefox job (Chrome would ignore `FIREFOX_VER` and
-duplicate the pinned PR-gate Chrome run). The `mealie-latest` leg still runs both browsers.
+duplicate the pinned PR-gate Chrome run). The `chrome-latest` leg runs **only** the Chrome job
+(Firefox would ignore the CfT override). The `mealie-latest` leg still runs both browsers.
 
 To run on your own server instead of GitHub-hosted, change `runs-on` to `[self-hosted]` —
 just ensure Docker is installed and the runner user is in the `docker` group. On a persistent
 runner, "latest" can go stale without care: Firefox is cached under a **version-keyed** directory
-(`~/.local/firefox-nonsnap-$FIREFOX_VER`), and `FIREFOX_VER=latest` always re-downloads; Mealie
-`compose up` **pulls** when `MEALIE_IMAGE` is set (the canary override) so `:latest` is refreshed.
+(`~/.local/firefox-nonsnap-$FIREFOX_VER`), and `FIREFOX_VER=latest` always re-downloads; Chrome for
+Testing is cached under `~/.cache/mini-mealie-chrome-for-testing` (clear it to force a refresh);
+Mealie `compose up` **pulls** when `MEALIE_IMAGE` is set (the canary override) so `:latest` is refreshed.
 GitHub-hosted `ubuntu-latest` is a fresh VM each run, so this only matters for self-hosted.
 The harnesses stay excluded from lint / tsc / vitest and from the AMO sources zip.

--- a/e2e-playwright/chrome-cft-smoke.ts
+++ b/e2e-playwright/chrome-cft-smoke.ts
@@ -1,0 +1,25 @@
+/**
+ * Tiny Playwright↔Chrome-for-Testing smoke for the chrome-latest canary leg.
+ *
+ * Launches PLAYWRIGHT_CHROME_EXECUTABLE with no extension and no suite — if this fails,
+ * treat the red leg as Playwright↔CfT tooling (or install/path), not product behavior.
+ * See docs/developers-guide/e2e-testing.md (Canary) and issue #183.
+ */
+import { chromium } from '@playwright/test';
+
+const executablePath = process.env.PLAYWRIGHT_CHROME_EXECUTABLE?.trim();
+if (!executablePath) {
+    throw new Error(
+        'PLAYWRIGHT_CHROME_EXECUTABLE is required (run pnpm test:e2e:chrome-cft:install first)',
+    );
+}
+
+const browser = await chromium.launch({ executablePath });
+const page = await browser.newPage();
+await page.goto('about:blank');
+const title = await page.title();
+await browser.close();
+
+console.log(
+    `chrome-cft-smoke ok: executablePath=${executablePath} title=${JSON.stringify(title)}`,
+);

--- a/e2e-playwright/fixtures.ts
+++ b/e2e-playwright/fixtures.ts
@@ -6,6 +6,10 @@ import { chromeExtensionDir } from '../e2e-shared/config';
  * Chromium E2E fixture. Mirrors Chrome's `--load-extension=…` flow (Playwright's
  * "Chrome extensions" pattern). Chrome MV3 uses a background service worker, so the
  * extension id comes from `context.serviceWorkers()`.
+ *
+ * PR gate / mealie-latest: Playwright's bundled Chromium (`channel: 'chromium'`).
+ * chrome-latest canary: Chrome for Testing via PLAYWRIGHT_CHROME_EXECUTABLE (still
+ * supports side-loading; branded Google Chrome does not).
  */
 
 export type MiniMealieFixtures = {
@@ -16,16 +20,25 @@ export type MiniMealieFixtures = {
     extensionBridgePage: Page;
 };
 
+function launchPersistentOptions(pathToExtension: string) {
+    const args = [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+    ];
+    const executablePath = process.env.PLAYWRIGHT_CHROME_EXECUTABLE?.trim();
+    if (executablePath) {
+        return { executablePath, args };
+    }
+    return { channel: 'chromium' as const, args };
+}
+
 export const test = base.extend<MiniMealieFixtures>({
     context: async ({}, use) => {
         const pathToExtension = chromeExtensionDir();
-        const browserContext = await chromium.launchPersistentContext('', {
-            channel: 'chromium',
-            args: [
-                `--disable-extensions-except=${pathToExtension}`,
-                `--load-extension=${pathToExtension}`,
-            ],
-        });
+        const browserContext = await chromium.launchPersistentContext(
+            '',
+            launchPersistentOptions(pathToExtension),
+        );
         await use(browserContext);
         await browserContext.close();
     },

--- a/e2e-playwright/install-chrome-for-testing.ts
+++ b/e2e-playwright/install-chrome-for-testing.ts
@@ -1,0 +1,54 @@
+/**
+ * Download Chrome for Testing for the chrome-latest canary leg.
+ *
+ * Prints `browser@buildId <executablePath>` (same shape as `@puppeteer/browsers install`)
+ * and, when running on GitHub Actions, appends PLAYWRIGHT_CHROME_EXECUTABLE to GITHUB_ENV.
+ *
+ * Tag defaults to `latest` (override with CHROME_FOR_TESTING_TAG, e.g. `stable`).
+ * Cache: E2E_CFT_CACHE_DIR or ~/.cache/mini-mealie-chrome-for-testing.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tag = process.env.CHROME_FOR_TESTING_TAG?.trim() || 'latest';
+const cacheDir =
+    process.env.E2E_CFT_CACHE_DIR?.trim() ||
+    path.join(os.homedir(), '.cache', 'mini-mealie-chrome-for-testing');
+
+fs.mkdirSync(cacheDir, { recursive: true });
+
+const result = spawnSync(
+    'npx',
+    ['-y', '@puppeteer/browsers', 'install', `chrome@${tag}`, '--path', cacheDir],
+    { encoding: 'utf8' },
+);
+
+const combined = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+if (result.status !== 0) {
+    console.error(combined || `npx @puppeteer/browsers failed (status ${result.status})`);
+    process.exit(result.status ?? 1);
+}
+
+// Format per CLI help: <browser>@<buildID> <path>
+const lines = combined.split('\n').map((l) => l.trim()).filter(Boolean);
+const line = [...lines].reverse().find((l) => /^chrome@\S+\s+\//.test(l));
+if (!line) {
+    console.error(`Could not parse Chrome for Testing path from install output:\n${combined}`);
+    process.exit(1);
+}
+
+const space = line.indexOf(' ');
+const buildLabel = line.slice(0, space);
+const executablePath = line.slice(space + 1).trim();
+if (!fs.existsSync(executablePath)) {
+    console.error(`Executable not found at ${executablePath}`);
+    process.exit(1);
+}
+
+console.log(`${buildLabel} ${executablePath}`);
+
+if (process.env.GITHUB_ENV) {
+    fs.appendFileSync(process.env.GITHUB_ENV, `PLAYWRIGHT_CHROME_EXECUTABLE=${executablePath}\n`);
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
         "test:e2e:up": "tsx e2e-shared/mealie-docker.ts up",
         "test:e2e:down": "tsx e2e-shared/mealie-docker.ts down",
         "test:e2e:chromium:install": "playwright install chromium",
+        "test:e2e:chrome-cft:install": "tsx e2e-playwright/install-chrome-for-testing.ts",
+        "test:e2e:chrome-cft:smoke": "tsx e2e-playwright/chrome-cft-smoke.ts",
         "test:e2e:chromium": "playwright test --config=e2e-playwright/playwright.config.ts",
         "test:e2e:gecko:setup": "bash e2e-geckodriver/setup.sh",
         "test:e2e:gecko": "cross-env WXT_E2E=true pnpm zip:firefox && tsx e2e-geckodriver/firefox-e2e.ts",


### PR DESCRIPTION
## Summary
- Adds a third weekly/manual canary leg, `chrome-latest`, so Chrome gets the same early-warning treatment as Mealie and Firefox ([#183](https://github.com/mrshappy0/mini-mealie/issues/183)).
- Keeps Playwright pinned. Downloads **Chrome for Testing `@latest`** (`@puppeteer/browsers`), drives it with `PLAYWRIGHT_CHROME_EXECUTABLE`, and side-loads the extension (branded Google Chrome can no longer do that in CI).
- Smoke step launches that binary with no extension first: smoke fail → Playwright↔CfT/tooling; smoke pass + suite fail → product/Chrome-behavior.
- Skips the Firefox job on that leg (would only re-run the pinned gate). Docs updated.

## Merge order
Please merge [#194](https://github.com/mrshappy0/mini-mealie/pull/194) **before** this PR.

PR-gate CI is fine without it (pinned Firefox 142). The weekly/manual `firefox-latest` canary needs #194 or that leg stays red on `main`.

## Why Chrome for Testing (not store Chrome)
Google Chrome removed the flags used to load unpacked extensions under automation. Playwright’s docs point extension tests at Chromium/CfT builds. CfT `@latest` still allows side-load and tracks a moving Chrome engine without bumping Playwright.

## Test plan
- [ ] PR `E2E` gate still uses Playwright’s bundled Chromium (empty `chrome_version`)
- [ ] Manual **E2E Canary**: three legs (`mealie-latest`, `firefox-latest`, `chrome-latest`), `fail-fast: false`
- [ ] `chrome-latest`: CfT install + smoke + Chrome suite; Firefox job skipped
- [ ] `firefox-latest`: Chrome job still skipped
- [ ] `mealie-latest`: both browsers still run

Closes #183
