### PR TITLE
ci(e2e): gate PRs on Mealie oldest and newest pins

### DIFF
--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -14,8 +14,8 @@ name: E2E Canary (latest upstream deps)
 # A smoke step launches that binary with no extension first: smoke fail → Playwright↔CfT/tooling;
 # smoke pass + suite fail → product/Chrome-behavior.
 #
-# The firefox-latest leg sets firefox_version so e2e.yml skips its chrome job (Chrome ignores
-# FIREFOX_VER). The chrome-latest leg sets chrome_version so e2e.yml skips its firefox job.
+# The firefox-latest leg sets firefox_version so e2e-suite.yml skips its chrome job (Chrome ignores
+# FIREFOX_VER). The chrome-latest leg sets chrome_version so e2e-suite.yml skips its firefox job.
 #
 # Note: `schedule` only fires from the repository's default branch. Until this is on the default
 # branch, run it manually via "Run workflow" (workflow_dispatch).
@@ -54,8 +54,9 @@ jobs:
                       mealie_image: ''
                       firefox_version: ''
                       chrome_version: latest
-        uses: ./.github/workflows/e2e.yml
+        uses: ./.github/workflows/e2e-suite.yml
         with:
             mealie_image: ${{ matrix.mealie_image }}
             firefox_version: ${{ matrix.firefox_version }}
             chrome_version: ${{ matrix.chrome_version }}
+            run_label: ${{ matrix.name }}

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -1,0 +1,151 @@
+name: E2E Suite
+
+# Reusable Chrome + Firefox e2e jobs. Called by the PR gate (e2e.yml) and the
+# weekly canary (e2e-canary.yml). Do not trigger this file on pull_request —
+# the gate owns the support-range matrix.
+
+on:
+    workflow_dispatch:
+        inputs:
+            mealie_image:
+                description: 'Mealie image (empty → newest from support-range.json via harness)'
+                type: string
+                required: false
+            firefox_version:
+                description: 'Firefox version for setup.sh (empty → pinned FIREFOX_VER; "latest" for newest)'
+                type: string
+                required: false
+            chrome_version:
+                description: 'Chrome for Testing tag (empty → Playwright bundled Chromium; "latest" for CfT canary)'
+                type: string
+                required: false
+            run_label:
+                description: 'Artifact name suffix (e.g. mealie-oldest)'
+                type: string
+                required: false
+    workflow_call:
+        inputs:
+            mealie_image:
+                description: 'Mealie image to test against (empty → newest from support-range.json via harness)'
+                type: string
+                required: false
+            firefox_version:
+                description: 'Firefox version for setup.sh (empty → the pinned FIREFOX_VER; "latest" for newest)'
+                type: string
+                required: false
+            chrome_version:
+                description: 'Chrome for Testing tag (empty → Playwright bundled Chromium; "latest" for CfT canary)'
+                type: string
+                required: false
+            run_label:
+                description: 'Artifact name suffix so parallel gate legs do not collide'
+                type: string
+                required: false
+
+permissions:
+    contents: read
+
+env:
+    # Gate / canary pass MEALIE_IMAGE explicitly. Empty → harness uses support-range newest.
+    MEALIE_IMAGE: ${{ inputs.mealie_image }}
+    FIREFOX_VER: ${{ inputs.firefox_version }}
+    CHROME_FOR_TESTING_TAG: ${{ inputs.chrome_version }}
+
+jobs:
+    chrome:
+        name: Chrome MV3
+        # Skip on the canary's firefox-latest leg: Chrome never reads FIREFOX_VER, so that run
+        # would be identical to the pinned PR-gate Chrome job (wasted CI, no new signal).
+        # Empty/unset on mealie-* gate legs / mealie-latest / chrome-latest → Chrome still runs.
+        if: ${{ !inputs.firefox_version }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v7
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v6
+
+            - name: Install Node.js
+              uses: actions/setup-node@v7
+              with:
+                  node-version: 22
+                  cache: 'pnpm'
+                  cache-dependency-path: |
+                      package.json
+                      pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install
+
+            # PR gate / mealie-*: Playwright's pinned Chromium. chrome-latest: Chrome for
+            # Testing @latest via executablePath (branded Google Chrome cannot side-load
+            # extensions; do not `playwright install chromium@latest` either — that fights the
+            # Playwright↔browser pairing).
+            - name: Install Playwright Chromium
+              if: ${{ !inputs.chrome_version }}
+              run: pnpm test:e2e:chromium:install
+
+            - name: Install Chrome for Testing
+              if: ${{ inputs.chrome_version == 'latest' }}
+              run: |
+                  pnpm exec playwright install-deps chromium
+                  pnpm test:e2e:chrome-cft:install
+
+            # Isolates Playwright↔CfT/tooling failures from product/Chrome-behavior failures.
+            - name: Smoke — launch Chrome for Testing under Playwright (no extension)
+              if: ${{ inputs.chrome_version == 'latest' }}
+              run: pnpm test:e2e:chrome-cft:smoke
+
+            - name: Run Chrome E2E (Docker Mealie + build + spec + teardown)
+              run: pnpm test:e2e
+              env:
+                  E2E_IMPORT_MODE: html
+
+            - name: Upload Playwright report
+              if: failure()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: playwright-report-${{ inputs.run_label || 'suite' }}
+                  path: e2e-playwright/playwright-report
+                  retention-days: 7
+
+    firefox:
+        name: Firefox MV2
+        # Skip on the canary's chrome-latest leg: Firefox never reads CfT overrides,
+        # so that run would duplicate the pinned PR-gate Firefox job.
+        if: ${{ !inputs.chrome_version }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v7
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v6
+
+            - name: Install Node.js
+              uses: actions/setup-node@v7
+              with:
+                  node-version: 22
+                  cache: 'pnpm'
+                  cache-dependency-path: |
+                      package.json
+                      pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Install non-snap Firefox + geckodriver
+              run: pnpm test:e2e:gecko:setup
+
+            - name: Start Dockerized Mealie
+              run: pnpm test:e2e:up
+
+            - name: Run Firefox E2E (zip:firefox + Selenium)
+              run: pnpm test:e2e:gecko
+              env:
+                  E2E_IMPORT_MODE: html
+
+            - name: Tear down Mealie
+              if: always()
+              run: pnpm test:e2e:down

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,137 +1,59 @@
 name: E2E
 
-# Full end-to-end tests: real browser + built extension + ephemeral Dockerized Mealie,
-# importing a hermetic local recipe fixture (no external site). See
-# docs/developers-guide/e2e-testing.md.
+# PR gate: prove both ends of the Mealie support range (see e2e-shared/support-range.json).
+# Each leg runs the full suite (Chrome + Firefox) against one Mealie tag with browsers on
+# their current pins — not a cartesian product with browser-range legs (those land under
+# sibling issues for Firefox / Chrome).
+#
+# Gate vs canary: this workflow proves the declared support range. e2e-canary.yml watches
+# brand-new upstream `:latest` releases (non-blocking early warning).
 
 on:
     pull_request:
         branches:
             - main
     workflow_dispatch:
-    # Callable by e2e-canary.yml to run the same jobs against newer upstream deps.
-    workflow_call:
-        inputs:
-            mealie_image:
-                description: 'Mealie image to test against (empty → the pinned version in mealie.e2e.yml)'
-                type: string
-                required: false
-            firefox_version:
-                description: 'Firefox version for setup.sh (empty → the pinned FIREFOX_VER; "latest" for newest)'
-                type: string
-                required: false
-            chrome_version:
-                description: 'Chrome for Testing tag (empty → Playwright bundled Chromium; "latest" for CfT canary)'
-                type: string
-                required: false
 
 permissions:
     contents: read
 
-env:
-    # Empty on pull_request / workflow_dispatch, so the harness falls back to the pinned
-    # defaults (Mealie v3.20.1 in mealie.e2e.yml, Firefox 142.0 in setup.sh, Playwright's
-    # bundled Chromium). The canary sets exactly one of these per matrix leg to isolate which
-    # upstream dep broke.
-    MEALIE_IMAGE: ${{ inputs.mealie_image }}
-    FIREFOX_VER: ${{ inputs.firefox_version }}
-    CHROME_FOR_TESTING_TAG: ${{ inputs.chrome_version }}
-
 jobs:
-    chrome:
-        name: Chrome MV3
-        # Skip on the canary's firefox-latest leg: Chrome never reads FIREFOX_VER, so that run
-        # would be identical to the pinned PR-gate Chrome job (wasted CI, no new signal).
-        # Empty/unset on pull_request and on mealie-latest / chrome-latest → Chrome still runs.
-        if: ${{ !inputs.firefox_version }}
+    resolve:
+        name: Resolve support range
         runs-on: ubuntu-latest
+        outputs:
+            mealie_oldest_image: ${{ steps.range.outputs.mealie_oldest_image }}
+            mealie_newest_image: ${{ steps.range.outputs.mealie_newest_image }}
+            mealie_oldest: ${{ steps.range.outputs.mealie_oldest }}
+            mealie_newest: ${{ steps.range.outputs.mealie_newest }}
         steps:
             - name: Checkout Code
               uses: actions/checkout@v7
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@v6
-
-            - name: Install Node.js
-              uses: actions/setup-node@v7
-              with:
-                  node-version: 22
-                  cache: 'pnpm'
-                  cache-dependency-path: |
-                      package.json
-                      pnpm-lock.yaml
-
-            - name: Install dependencies
-              run: pnpm install
-
-            # PR gate / mealie-latest: Playwright's pinned Chromium. chrome-latest: Chrome for
-            # Testing @latest via executablePath (branded Google Chrome cannot side-load
-            # extensions; do not `playwright install chromium@latest` either — that fights the
-            # Playwright↔browser pairing).
-            - name: Install Playwright Chromium
-              if: ${{ !inputs.chrome_version }}
-              run: pnpm test:e2e:chromium:install
-
-            - name: Install Chrome for Testing
-              if: ${{ inputs.chrome_version == 'latest' }}
+            - name: Read e2e-shared/support-range.json
+              id: range
               run: |
-                  pnpm exec playwright install-deps chromium
-                  pnpm test:e2e:chrome-cft:install
+                  repo=$(jq -r '.mealie.repository' e2e-shared/support-range.json)
+                  oldest=$(jq -r '.mealie.oldest' e2e-shared/support-range.json)
+                  newest=$(jq -r '.mealie.newest' e2e-shared/support-range.json)
+                  echo "mealie_oldest=${oldest}" >> "$GITHUB_OUTPUT"
+                  echo "mealie_newest=${newest}" >> "$GITHUB_OUTPUT"
+                  echo "mealie_oldest_image=${repo}:${oldest}" >> "$GITHUB_OUTPUT"
+                  echo "mealie_newest_image=${repo}:${newest}" >> "$GITHUB_OUTPUT"
+                  echo "Mealie support range: ${oldest} … ${newest}"
 
-            # Isolates Playwright↔CfT/tooling failures from product/Chrome-behavior failures.
-            - name: Smoke — launch Chrome for Testing under Playwright (no extension)
-              if: ${{ inputs.chrome_version == 'latest' }}
-              run: pnpm test:e2e:chrome-cft:smoke
+    mealie-oldest:
+        name: mealie-oldest (${{ needs.resolve.outputs.mealie_oldest }})
+        needs: resolve
+        uses: ./.github/workflows/e2e-suite.yml
+        with:
+            mealie_image: ${{ needs.resolve.outputs.mealie_oldest_image }}
+            run_label: mealie-oldest
 
-            - name: Run Chrome E2E (Docker Mealie + build + spec + teardown)
-              run: pnpm test:e2e
-              env:
-                  E2E_IMPORT_MODE: html
-
-            - name: Upload Playwright report
-              if: failure()
-              uses: actions/upload-artifact@v7
-              with:
-                  name: playwright-report
-                  path: e2e-playwright/playwright-report
-                  retention-days: 7
-
-    firefox:
-        name: Firefox MV2
-        # Skip on the canary's chrome-latest leg: Firefox never reads CfT overrides,
-        # so that run would duplicate the pinned PR-gate Firefox job.
-        if: ${{ !inputs.chrome_version }}
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@v7
-
-            - name: Install pnpm
-              uses: pnpm/action-setup@v6
-
-            - name: Install Node.js
-              uses: actions/setup-node@v7
-              with:
-                  node-version: 22
-                  cache: 'pnpm'
-                  cache-dependency-path: |
-                      package.json
-                      pnpm-lock.yaml
-
-            - name: Install dependencies
-              run: pnpm install
-
-            - name: Install non-snap Firefox + geckodriver
-              run: pnpm test:e2e:gecko:setup
-
-            - name: Start Dockerized Mealie
-              run: pnpm test:e2e:up
-
-            - name: Run Firefox E2E (zip:firefox + Selenium)
-              run: pnpm test:e2e:gecko
-              env:
-                  E2E_IMPORT_MODE: html
-
-            - name: Tear down Mealie
-              if: always()
-              run: pnpm test:e2e:down
+    mealie-newest:
+        name: mealie-newest (${{ needs.resolve.outputs.mealie_newest }})
+        needs: resolve
+        uses: ./.github/workflows/e2e-suite.yml
+        with:
+            mealie_image: ${{ needs.resolve.outputs.mealie_newest_image }}
+            run_label: mealie-newest

--- a/docker/mealie.e2e.yml
+++ b/docker/mealie.e2e.yml
@@ -1,5 +1,8 @@
 # Ephemeral Mealie for E2E. Runs standalone on SQLite (no external DB), data in
-# tmpfs so every run starts clean. Image is overridable via MEALIE_IMAGE.
+# tmpfs so every run starts clean.
+#
+# MEALIE_IMAGE is required. Prefer `pnpm test:e2e:up` (sets newest from
+# e2e-shared/support-range.json). CI passes oldest/newest explicitly.
 #
 #   docker compose -f docker/mealie.e2e.yml up -d
 #   docker compose -f docker/mealie.e2e.yml down -v
@@ -8,7 +11,7 @@
 # logs in with those and mints an API token (see e2e-shared/mealie-docker.ts).
 services:
     mealie:
-        image: ${MEALIE_IMAGE:-ghcr.io/mealie-recipes/mealie:v3.20.1}
+        image: ${MEALIE_IMAGE:?Set MEALIE_IMAGE or use pnpm test:e2e:up}
         container_name: mini-mealie-e2e
         ports:
             - '${MEALIE_PORT:-9925}:9000'

--- a/docs/developers-guide/e2e-testing.md
+++ b/docs/developers-guide/e2e-testing.md
@@ -40,7 +40,8 @@ Both harnesses run the same flow:
 ## The Mealie backend (Docker)
 
 `docker/mealie.e2e.yml` runs an ephemeral Mealie on SQLite (tmpfs, so every run is clean).
-`e2e-shared/mealie-docker.ts` brings it up, waits for health, logs in with Mealie's default
+`e2e-shared/mealie-docker.ts` brings it up (image from `MEALIE_IMAGE` or **newest** in
+`e2e-shared/support-range.json`), waits for health, logs in with Mealie's default
 `changeme@example.com` / `MyPassword`, mints an API token, and writes `.env.e2e`
 (`E2E_MEALIE_SERVER`, `E2E_MEALIE_TOKEN`). Both harnesses auto-load `.env.e2e`.
 
@@ -86,32 +87,60 @@ pnpm test:e2e:down
 | `E2E_IMPORT_MODE` | `html` | `html` or `url` import mode |
 | `E2E_RECIPE_URL` | local fixture | recipe to import; set a real URL for a live-scrape run |
 | `E2E_FIXTURE_PORT` | `8730` | port for the local fixture server |
-| `MEALIE_IMAGE` / `MEALIE_PORT` | `…/mealie:v3.20.1` / `9925` | Docker Mealie image / host port |
+| `MEALIE_IMAGE` / `MEALIE_PORT` | newest from `support-range.json` / `9925` | Docker Mealie image / host port |
 | `E2E_FIREFOX_XPI` | newest `.output/*-firefox.zip` | Firefox add-on to install |
 | `FIREFOX_VER` | `142.0` (pinned) | Firefox version `setup.sh` fetches; set `latest` for the canary |
 | `PLAYWRIGHT_CHROME_EXECUTABLE` | (unset → Playwright Chromium) | absolute path to Chrome for Testing (canary) |
 | `CHROME_FOR_TESTING_TAG` | `latest` | tag passed to `@puppeteer/browsers` (`latest`, `stable`, …) |
 | `E2E_HEADLESS` | on | set `0` to watch Firefox run |
 
-## CI
+## Support range
 
-`.github/workflows/e2e.yml` runs both targets on every PR to `main` (and `workflow_dispatch`):
+`e2e-shared/support-range.json` is the **single source of truth** for which Mealie versions we
+claim to support. Local `pnpm test:e2e:up` uses **newest** Mealie when `MEALIE_IMAGE` is unset.
+Compose requires `MEALIE_IMAGE` — always go through the harness or set it yourself from that file.
+
+| End | Mealie tag | Rolling rule |
+| --- | --- | --- |
+| **Oldest** | `v3.19.2` | Latest patch of **newest − 2 minors** |
+| **Newest** | `v3.20.1` | Latest stable the gate (or a bump PR) has proven green |
+
+Raising `mealie.oldest` is an intentional change: edit the JSON and say so in the PR / release
+notes. Do not raise the floor as a side effect of chasing “latest.” Firefox and Chrome still use
+a single pin each; browser support-range fields land under sibling issues of
+[#193](https://github.com/mrshappy0/mini-mealie/issues/193).
+
+## CI (PR gate)
+
+`.github/workflows/e2e.yml` is the **merge gate**. On every PR to `main` (and
+`workflow_dispatch`) it reads `support-range.json` and runs the reusable suite
+(`.github/workflows/e2e-suite.yml`) twice:
+
+| Leg | Mealie | Browsers |
+| --- | --- | --- |
+| `mealie-oldest` | oldest tag | Chrome + Firefox (current pins) |
+| `mealie-newest` | newest tag | Chrome + Firefox (current pins) |
+
+One moving piece per leg (same idea as the canary) — not a full Mealie × browser grid.
 
 - Docker + Compose ship on `ubuntu-latest`, so `test:e2e:up` brings up Mealie there exactly
   as it does locally.
 - No secrets: Mealie is ephemeral and the API token is minted at runtime.
 - Fully hermetic: the default recipe is the local fixture, so no third-party site can flake CI.
 - Chrome uses the self-contained `pnpm test:e2e`; Firefox adds the `setup.sh` step.
-- **Everything pinned** so the gate is deterministic — a red PR means *your* change broke, not
-  that an upstream dep shipped a release: Mealie (`v3.20.1`), Firefox (`142.0`), geckodriver
-  (`v0.36.0`), and Chromium (frozen inside the Playwright dep).
+- **Pinned ends** so the gate is deterministic — a red PR means *your* change broke something
+  in the support range, not that an upstream dep just shipped: Mealie (`oldest`…`newest`),
+  Firefox (`142.0`), geckodriver (`v0.36.0`), and Chromium (frozen inside the Playwright dep).
 
 ## Canary (early warning)
 
 `.github/workflows/e2e-canary.yml` runs the same suite weekly (and on demand) against the
-**latest** of the dependencies we fetch at runtime, so upstream releases that break the extension
-surface *here* before they reach the pinned PR gate. It's **non-blocking** — a heads-up, not a
-merge gate — and reuses `e2e.yml` via `workflow_call`.
+**latest** of the dependencies we fetch at runtime, so brand-new upstream releases that break
+the extension surface *here* before we raise the support-range ceiling. It's **non-blocking** —
+a heads-up, not a merge gate — and reuses `e2e-suite.yml` via `workflow_call`.
+
+**Gate vs canary:** the gate proves the declared support range; the canary watches floating
+`:latest` / `latest` upstreams.
 
 It's a **matrix with one leg per moving dependency**, each holding the others pinned so a red leg
 names the culprit:
@@ -119,8 +148,8 @@ names the culprit:
 | Leg | Overrides | Pinned | Jobs |
 | --- | --- | --- | --- |
 | `mealie-latest` | Mealie → `:latest` | Firefox `142.0`, Playwright Chromium | Chrome + Firefox |
-| `firefox-latest` | Firefox → `latest` (also catches geckodriver/Firefox skew) | Mealie `v3.20.1` | Firefox only |
-| `chrome-latest` | Chrome for Testing → `latest` via `PLAYWRIGHT_CHROME_EXECUTABLE` | Mealie `v3.20.1`, Firefox `142.0`, Playwright version | Chrome only |
+| `firefox-latest` | Firefox → `latest` (also catches geckodriver/Firefox skew) | Mealie newest pin | Firefox only |
+| `chrome-latest` | Chrome for Testing → `latest` via `PLAYWRIGHT_CHROME_EXECUTABLE` | Mealie newest pin, Firefox `142.0`, Playwright version | Chrome only |
 
 `chrome-latest` keeps Playwright pinned and downloads **Chrome for Testing** `@latest`
 (`pnpm test:e2e:chrome-cft:install`), then drives it with `executablePath`. Branded Google Chrome
@@ -137,7 +166,7 @@ broke the extension. (Addresses
 otherwise.
 
 The `firefox-latest` leg runs **only** the Firefox job (Chrome would ignore `FIREFOX_VER` and
-duplicate the pinned PR-gate Chrome run). The `chrome-latest` leg runs **only** the Chrome job
+duplicate a gate Chrome run). The `chrome-latest` leg runs **only** the Chrome job
 (Firefox would ignore the CfT override). The `mealie-latest` leg still runs both browsers.
 
 To run on your own server instead of GitHub-hosted, change `runs-on` to `[self-hosted]` —
@@ -145,6 +174,6 @@ just ensure Docker is installed and the runner user is in the `docker` group. On
 runner, "latest" can go stale without care: Firefox is cached under a **version-keyed** directory
 (`~/.local/firefox-nonsnap-$FIREFOX_VER`), and `FIREFOX_VER=latest` always re-downloads; Chrome for
 Testing is cached under `~/.cache/mini-mealie-chrome-for-testing` (clear it to force a refresh);
-Mealie `compose up` **pulls** when `MEALIE_IMAGE` is set (the canary override) so `:latest` is refreshed.
+Mealie `compose` **pulls** only for floating `:latest` images so the canary refreshes.
 GitHub-hosted `ubuntu-latest` is a fresh VM each run, so this only matters for self-hosted.
 The harnesses stay excluded from lint / tsc / vitest and from the AMO sources zip.

--- a/e2e-shared/mealie-docker.ts
+++ b/e2e-shared/mealie-docker.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { REPO_ROOT } from './config';
+import { defaultMealieImage } from './support-range';
 
 /**
  * Ephemeral Dockerized Mealie for E2E: bring it up, mint an API token, tear it down.
@@ -10,6 +11,8 @@ import { REPO_ROOT } from './config';
  *
  *   tsx e2e-shared/mealie-docker.ts up     # start + write .env.e2e (server + token)
  *   tsx e2e-shared/mealie-docker.ts down   # stop + remove volumes
+ *
+ * Image pin: `MEALIE_IMAGE` if set, else newest from `e2e-shared/support-range.json`.
  */
 
 const COMPOSE_FILE = path.join(REPO_ROOT, 'docker/mealie.e2e.yml');
@@ -21,10 +24,15 @@ const ENV_FILE = path.join(REPO_ROOT, '.env.e2e');
 const DEFAULT_EMAIL = 'changeme@example.com';
 const DEFAULT_PASSWORD = 'MyPassword';
 
-function compose(args: string[]): void {
+function resolveMealieImage(): string {
+    return process.env.MEALIE_IMAGE?.trim() || defaultMealieImage();
+}
+
+function compose(args: string[], env: NodeJS.ProcessEnv = process.env): void {
     execFileSync('docker', ['compose', '-p', 'mini-mealie-e2e', '-f', COMPOSE_FILE, ...args], {
         stdio: 'inherit',
         cwd: REPO_ROOT,
+        env,
     });
 }
 
@@ -74,13 +82,15 @@ export type MealieHandle = { server: string; token: string };
 
 /** Start Mealie (if not already up), wait for health, mint a fresh API token. */
 export async function mealieUp(): Promise<MealieHandle> {
-    // When MEALIE_IMAGE is set (canary mealie-latest), re-pull so a self-hosted runner
-    // doesn't keep a stale `:latest` (compose up alone won't refresh an existing local tag).
-    // PR-gate runs leave MEALIE_IMAGE unset and use the pinned image — no pull needed.
-    if (process.env.MEALIE_IMAGE?.trim()) {
-        compose(['pull']);
+    const image = resolveMealieImage();
+    const env = { ...process.env, MEALIE_IMAGE: image };
+    // Re-pull floating tags (canary `:latest`) so a self-hosted runner doesn't keep a
+    // stale local image. Pinned tags are content-addressed enough — skip the pull.
+    if (image.endsWith(':latest')) {
+        compose(['pull'], env);
     }
-    compose(['up', '-d']);
+    console.log(`[mealie] using image ${image}`);
+    compose(['up', '-d'], env);
     await waitForHealthy();
     const accessToken = await login();
     const token = await mintApiToken(accessToken);

--- a/e2e-shared/mealie-docker.ts
+++ b/e2e-shared/mealie-docker.ts
@@ -99,7 +99,8 @@ export async function mealieUp(): Promise<MealieHandle> {
 
 /** Stop Mealie and remove its (tmpfs) volumes. */
 export function mealieDown(): void {
-    compose(['down', '-v']);
+    const image = resolveMealieImage();
+    compose(['down', '-v'], { ...process.env, MEALIE_IMAGE: image });
 }
 
 async function main(): Promise<void> {

--- a/e2e-shared/support-range.json
+++ b/e2e-shared/support-range.json
@@ -1,0 +1,7 @@
+{
+    "mealie": {
+        "repository": "ghcr.io/mealie-recipes/mealie",
+        "oldest": "v3.19.2",
+        "newest": "v3.20.1"
+    }
+}

--- a/e2e-shared/support-range.ts
+++ b/e2e-shared/support-range.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { REPO_ROOT } from './config';
+
+/**
+ * Supported Mealie ends for the PR e2e gate.
+ * Source of truth: `e2e-shared/support-range.json`.
+ * Raising `mealie.oldest` is an intentional, documented change.
+ */
+export type SupportRange = {
+    mealie: {
+        repository: string;
+        oldest: string;
+        newest: string;
+    };
+};
+
+let cached: SupportRange | undefined;
+
+export function loadSupportRange(): SupportRange {
+    if (cached) return cached;
+    const file = path.join(REPO_ROOT, 'e2e-shared/support-range.json');
+    cached = JSON.parse(readFileSync(file, 'utf8')) as SupportRange;
+    return cached;
+}
+
+/** Full image ref for a Mealie tag from the support file (e.g. `…/mealie:v3.20.1`). */
+export function mealieImageFor(tag: string, range = loadSupportRange()): string {
+    return `${range.mealie.repository}:${tag}`;
+}
+
+/** Default local / unset-env Mealie image: newest end of the support range. */
+export function defaultMealieImage(range = loadSupportRange()): string {
+    return mealieImageFor(range.mealie.newest, range);
+}


### PR DESCRIPTION
## Summary
- Add `e2e-shared/support-range.json` as the single source of truth for Mealie oldest/newest (`v3.19.2` … `v3.20.1`).
- Split the reusable Chrome + Firefox jobs into `e2e-suite.yml`; PR `e2e.yml` becomes a thin gate that runs `mealie-oldest` and `mealie-newest`.
- Canary still watches Mealie `:latest` only (via the shared suite). Compose / harness defaults read the JSON instead of a second pin in `mealie.e2e.yml`.

Implements #196 (parent #193).

## Merge order
Please merge **#195** before this PR (this branch is stacked on it). The suite extraction assumes the Chrome for Testing canary wiring from #195.

## Test plan
- [ ] PR E2E shows named checks `mealie-oldest (v3.19.2)` and `mealie-newest (v3.20.1)`
- [ ] Each Mealie leg still runs Chrome (Playwright Chromium) + Firefox
- [ ] Canary `mealie-latest` / `firefox-latest` / `chrome-latest` still call `e2e-suite.yml`
- [ ] Local `pnpm test:e2e:up` uses newest Mealie from the JSON when `MEALIE_IMAGE` is unset
- [ ] Raising `mealie.oldest` is only via editing the JSON

Closes #196