### PR TITLE
ci(e2e): gate PRs on Chrome oldest and newest pins

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -16,7 +16,7 @@ on:
                 type: string
                 required: false
             chrome_version:
-                description: 'Chrome for Testing tag (empty → Playwright bundled Chromium; "latest" for CfT canary)'
+                description: 'CfT build id or "latest" (empty → Playwright Chromium + Firefox; set → CfT only)'
                 type: string
                 required: false
             run_label:
@@ -34,7 +34,7 @@ on:
                 type: string
                 required: false
             chrome_version:
-                description: 'Chrome for Testing tag (empty → Playwright bundled Chromium; "latest" for CfT canary)'
+                description: 'CfT build id or "latest" (empty → Playwright Chromium + Firefox; set → CfT only)'
                 type: string
                 required: false
             run_label:
@@ -56,7 +56,7 @@ jobs:
         name: Chrome MV3
         # Skip on the canary's firefox-latest leg: Chrome never reads FIREFOX_VER, so that run
         # would be identical to the pinned PR-gate Chrome job (wasted CI, no new signal).
-        # Empty/unset on mealie-* gate legs / mealie-latest / chrome-latest → Chrome still runs.
+        # Empty/unset (mealie-*) / CfT pin / chrome-latest → Chrome still runs.
         if: ${{ !inputs.firefox_version }}
         runs-on: ubuntu-latest
         steps:
@@ -78,23 +78,23 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
-            # PR gate / mealie-*: Playwright's pinned Chromium. chrome-latest: Chrome for
-            # Testing @latest via executablePath (branded Google Chrome cannot side-load
-            # extensions; do not `playwright install chromium@latest` either — that fights the
-            # Playwright↔browser pairing).
+            # Empty (mealie-* / mealie-latest): Playwright's bundled Chromium (harness default).
+            # Set (chrome-oldest / chrome-newest pin, or canary "latest"): Chrome for Testing via
+            # executablePath. Branded Google Chrome cannot side-load extensions; do not
+            # `playwright install chromium@latest` either — that fights the Playwright↔browser pairing.
             - name: Install Playwright Chromium
               if: ${{ !inputs.chrome_version }}
               run: pnpm test:e2e:chromium:install
 
             - name: Install Chrome for Testing
-              if: ${{ inputs.chrome_version == 'latest' }}
+              if: ${{ inputs.chrome_version }}
               run: |
                   pnpm exec playwright install-deps chromium
                   pnpm test:e2e:chrome-cft:install
 
             # Isolates Playwright↔CfT/tooling failures from product/Chrome-behavior failures.
             - name: Smoke — launch Chrome for Testing under Playwright (no extension)
-              if: ${{ inputs.chrome_version == 'latest' }}
+              if: ${{ inputs.chrome_version }}
               run: pnpm test:e2e:chrome-cft:smoke
 
             - name: Run Chrome E2E (Docker Mealie + build + spec + teardown)
@@ -112,8 +112,8 @@ jobs:
 
     firefox:
         name: Firefox MV2
-        # Skip on the canary's chrome-latest leg: Firefox never reads CfT overrides,
-        # so that run would duplicate the pinned PR-gate Firefox job.
+        # Skip when chrome_version is set (chrome-oldest / chrome-newest / chrome-latest):
+        # Firefox never reads CfT overrides, so that run would duplicate a mealie-* Firefox job.
         if: ${{ !inputs.chrome_version }}
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,12 +1,14 @@
 name: E2E
 
-# PR gate: prove both ends of the Mealie support range (see e2e-shared/support-range.json).
-# Each leg runs the full suite (Chrome + Firefox) against one Mealie tag with browsers on
-# their current pins — not a cartesian product with browser-range legs (those land under
-# sibling issues for Firefox / Chrome).
+# PR gate: prove both ends of each declared support range (see e2e-shared/support-range.json).
+# One moving piece per leg — not a cartesian product across Mealie × Chrome × Firefox.
+#
+# Mealie legs: both browsers on current pins (Playwright Chromium + pinned Firefox).
+# Chrome legs: Mealie on newest pin; Firefox skipped. Both ends are pinned Chrome for Testing
+# builds (oldest = newest − 2 milestones) so the gate proves backward compatibility.
 #
 # Gate vs canary: this workflow proves the declared support range. e2e-canary.yml watches
-# brand-new upstream `:latest` releases (non-blocking early warning).
+# brand-new upstream `:latest` / `latest` releases (non-blocking early warning).
 
 on:
     pull_request:
@@ -26,6 +28,8 @@ jobs:
             mealie_newest_image: ${{ steps.range.outputs.mealie_newest_image }}
             mealie_oldest: ${{ steps.range.outputs.mealie_oldest }}
             mealie_newest: ${{ steps.range.outputs.mealie_newest }}
+            chrome_oldest: ${{ steps.range.outputs.chrome_oldest }}
+            chrome_newest: ${{ steps.range.outputs.chrome_newest }}
         steps:
             - name: Checkout Code
               uses: actions/checkout@v7
@@ -36,11 +40,16 @@ jobs:
                   repo=$(jq -r '.mealie.repository' e2e-shared/support-range.json)
                   oldest=$(jq -r '.mealie.oldest' e2e-shared/support-range.json)
                   newest=$(jq -r '.mealie.newest' e2e-shared/support-range.json)
+                  chrome_oldest=$(jq -r '.chrome.oldest' e2e-shared/support-range.json)
+                  chrome_newest=$(jq -r '.chrome.newest' e2e-shared/support-range.json)
                   echo "mealie_oldest=${oldest}" >> "$GITHUB_OUTPUT"
                   echo "mealie_newest=${newest}" >> "$GITHUB_OUTPUT"
                   echo "mealie_oldest_image=${repo}:${oldest}" >> "$GITHUB_OUTPUT"
                   echo "mealie_newest_image=${repo}:${newest}" >> "$GITHUB_OUTPUT"
+                  echo "chrome_oldest=${chrome_oldest}" >> "$GITHUB_OUTPUT"
+                  echo "chrome_newest=${chrome_newest}" >> "$GITHUB_OUTPUT"
                   echo "Mealie support range: ${oldest} … ${newest}"
+                  echo "Chrome support range: ${chrome_oldest} … ${chrome_newest}"
 
     mealie-oldest:
         name: mealie-oldest (${{ needs.resolve.outputs.mealie_oldest }})
@@ -57,3 +66,23 @@ jobs:
         with:
             mealie_image: ${{ needs.resolve.outputs.mealie_newest_image }}
             run_label: mealie-newest
+
+    # Both Chrome ends: pinned CfT (not branded Google Chrome). Setting chrome_version skips
+    # Firefox (same skip idea as chrome-latest canary) so this leg only moves the browser.
+    chrome-oldest:
+        name: chrome-oldest (${{ needs.resolve.outputs.chrome_oldest }})
+        needs: resolve
+        uses: ./.github/workflows/e2e-suite.yml
+        with:
+            mealie_image: ${{ needs.resolve.outputs.mealie_newest_image }}
+            chrome_version: ${{ needs.resolve.outputs.chrome_oldest }}
+            run_label: chrome-oldest
+
+    chrome-newest:
+        name: chrome-newest (${{ needs.resolve.outputs.chrome_newest }})
+        needs: resolve
+        uses: ./.github/workflows/e2e-suite.yml
+        with:
+            mealie_image: ${{ needs.resolve.outputs.mealie_newest_image }}
+            chrome_version: ${{ needs.resolve.outputs.chrome_newest }}
+            run_label: chrome-newest

--- a/docs/developers-guide/e2e-testing.md
+++ b/docs/developers-guide/e2e-testing.md
@@ -90,38 +90,46 @@ pnpm test:e2e:down
 | `MEALIE_IMAGE` / `MEALIE_PORT` | newest from `support-range.json` / `9925` | Docker Mealie image / host port |
 | `E2E_FIREFOX_XPI` | newest `.output/*-firefox.zip` | Firefox add-on to install |
 | `FIREFOX_VER` | `142.0` (pinned) | Firefox version `setup.sh` fetches; set `latest` for the canary |
-| `PLAYWRIGHT_CHROME_EXECUTABLE` | (unset → Playwright Chromium) | absolute path to Chrome for Testing (canary) |
-| `CHROME_FOR_TESTING_TAG` | `latest` | tag passed to `@puppeteer/browsers` (`latest`, `stable`, …) |
+| `PLAYWRIGHT_CHROME_EXECUTABLE` | (unset → Playwright Chromium) | absolute path to Chrome for Testing |
+| `CHROME_FOR_TESTING_TAG` | `latest` | tag / build id for `@puppeteer/browsers` (`151.0.7922.47`, `stable`, `latest`, …) |
 | `E2E_HEADLESS` | on | set `0` to watch Firefox run |
 
 ## Support range
 
-`e2e-shared/support-range.json` is the **single source of truth** for which Mealie versions we
-claim to support. Local `pnpm test:e2e:up` uses **newest** Mealie when `MEALIE_IMAGE` is unset.
-Compose requires `MEALIE_IMAGE` — always go through the harness or set it yourself from that file.
+`e2e-shared/support-range.json` is the **single source of truth** for which Mealie and Chrome
+ends we claim to support. Local `pnpm test:e2e:up` uses **newest** Mealie when `MEALIE_IMAGE`
+is unset. Compose requires `MEALIE_IMAGE` — always go through the harness or set it yourself
+from that file.
 
-| End | Mealie tag | Rolling rule |
-| --- | --- | --- |
-| **Oldest** | `v3.19.2` | Latest patch of **newest − 2 minors** |
-| **Newest** | `v3.20.1` | Latest stable the gate (or a bump PR) has proven green |
+| End | Mealie | Chrome (CfT) | Rolling rule |
+| --- | --- | --- | --- |
+| **Oldest** | `v3.19.2` | `149.0.7827.155` | Mealie: latest patch of **newest − 2 minors**. Chrome: latest build of **newest − 2 milestones**. |
+| **Newest** | `v3.20.1` | `151.0.7922.47` | Latest stable the gate (or a bump PR) has proven green |
 
-Raising `mealie.oldest` is an intentional change: edit the JSON and say so in the PR / release
-notes. Do not raise the floor as a side effect of chasing “latest.” Firefox and Chrome still use
-a single pin each; browser support-range fields land under sibling issues of
-[#193](https://github.com/mrshappy0/mini-mealie/issues/193).
+Raising any `*.oldest` field is an intentional change: edit the JSON and say so in the PR /
+release notes. Do not raise a floor as a side effect of chasing “latest.” Firefox still uses a
+single pin; its support-range fields land under
+[#198](https://github.com/mrshappy0/mini-mealie/issues/198).
+
+**No branded Google Chrome in CI.** Store Chrome removed the flags needed to side-load unpacked
+extensions. Gate Chrome range legs and the canary use **Chrome for Testing** only. Mealie legs
+still use Playwright’s bundled Chromium as the harness default (not a support-range end).
 
 ## CI (PR gate)
 
 `.github/workflows/e2e.yml` is the **merge gate**. On every PR to `main` (and
 `workflow_dispatch`) it reads `support-range.json` and runs the reusable suite
-(`.github/workflows/e2e-suite.yml`) twice:
+(`.github/workflows/e2e-suite.yml`) once per named leg:
 
-| Leg | Mealie | Browsers |
-| --- | --- | --- |
-| `mealie-oldest` | oldest tag | Chrome + Firefox (current pins) |
-| `mealie-newest` | newest tag | Chrome + Firefox (current pins) |
+| Leg | Mealie | Chrome | Firefox |
+| --- | --- | --- | --- |
+| `mealie-oldest` | oldest tag | Playwright Chromium | pinned `142.0` |
+| `mealie-newest` | newest tag | Playwright Chromium | pinned `142.0` |
+| `chrome-oldest` | newest tag | CfT `149.0.7827.155` | skipped |
+| `chrome-newest` | newest tag | CfT `151.0.7922.47` | skipped |
 
 One moving piece per leg (same idea as the canary) — not a full Mealie × browser grid.
+`chrome-*` legs skip Firefox so a red check names the browser, not a duplicate Firefox run.
 
 - Docker + Compose ship on `ubuntu-latest`, so `test:e2e:up` brings up Mealie there exactly
   as it does locally.
@@ -130,7 +138,7 @@ One moving piece per leg (same idea as the canary) — not a full Mealie × brow
 - Chrome uses the self-contained `pnpm test:e2e`; Firefox adds the `setup.sh` step.
 - **Pinned ends** so the gate is deterministic — a red PR means *your* change broke something
   in the support range, not that an upstream dep just shipped: Mealie (`oldest`…`newest`),
-  Firefox (`142.0`), geckodriver (`v0.36.0`), and Chromium (frozen inside the Playwright dep).
+  Chrome (pinned CfT oldest…newest), Firefox (`142.0`), geckodriver (`v0.36.0`).
 
 ## Canary (early warning)
 
@@ -140,7 +148,7 @@ the extension surface *here* before we raise the support-range ceiling. It's **n
 a heads-up, not a merge gate — and reuses `e2e-suite.yml` via `workflow_call`.
 
 **Gate vs canary:** the gate proves the declared support range; the canary watches floating
-`:latest` / `latest` upstreams.
+`:latest` / `latest` upstreams only (not a third pin in `support-range.json`).
 
 It's a **matrix with one leg per moving dependency**, each holding the others pinned so a red leg
 names the culprit:
@@ -153,8 +161,8 @@ names the culprit:
 
 `chrome-latest` keeps Playwright pinned and downloads **Chrome for Testing** `@latest`
 (`pnpm test:e2e:chrome-cft:install`), then drives it with `executablePath`. Branded Google Chrome
-is not used — Google removed the flags needed to side-load unpacked extensions. Do **not** try
-`playwright install chromium@latest` either — that fights Playwright's bundled-browser pairing.
+is not used. Do **not** try `playwright install chromium@latest` either — that fights Playwright's
+bundled-browser pairing.
 
 Before the suite, a smoke step (`pnpm test:e2e:chrome-cft:smoke`) launches that binary with no
 extension: smoke fail → Playwright↔CfT/tooling (or install/path); smoke pass + suite fail →

--- a/e2e-playwright/chrome-cft-smoke.ts
+++ b/e2e-playwright/chrome-cft-smoke.ts
@@ -1,5 +1,5 @@
 /**
- * Tiny Playwright↔Chrome-for-Testing smoke for the chrome-latest canary leg.
+ * Tiny Playwright↔Chrome-for-Testing smoke for chrome-newest / chrome-latest.
  *
  * Launches PLAYWRIGHT_CHROME_EXECUTABLE with no extension and no suite — if this fails,
  * treat the red leg as Playwright↔CfT tooling (or install/path), not product behavior.

--- a/e2e-playwright/fixtures.ts
+++ b/e2e-playwright/fixtures.ts
@@ -7,9 +7,9 @@ import { chromeExtensionDir } from '../e2e-shared/config';
  * "Chrome extensions" pattern). Chrome MV3 uses a background service worker, so the
  * extension id comes from `context.serviceWorkers()`.
  *
- * PR gate / mealie-latest: Playwright's bundled Chromium (`channel: 'chromium'`).
- * chrome-latest canary: Chrome for Testing via PLAYWRIGHT_CHROME_EXECUTABLE (still
- * supports side-loading; branded Google Chrome does not).
+ * mealie-* / mealie-latest: Playwright's bundled Chromium (`channel: 'chromium'`).
+ * chrome-oldest / chrome-newest / chrome-latest: Chrome for Testing via
+ * PLAYWRIGHT_CHROME_EXECUTABLE (still supports side-loading; branded Google Chrome does not).
  */
 
 export type MiniMealieFixtures = {

--- a/e2e-playwright/install-chrome-for-testing.ts
+++ b/e2e-playwright/install-chrome-for-testing.ts
@@ -1,10 +1,11 @@
 /**
- * Download Chrome for Testing for the chrome-latest canary leg.
+ * Download Chrome for Testing for chrome-newest (pinned Stable) and chrome-latest (canary).
  *
  * Prints `browser@buildId <executablePath>` (same shape as `@puppeteer/browsers install`)
  * and, when running on GitHub Actions, appends PLAYWRIGHT_CHROME_EXECUTABLE to GITHUB_ENV.
  *
- * Tag defaults to `latest` (override with CHROME_FOR_TESTING_TAG, e.g. `stable`).
+ * Tag from CHROME_FOR_TESTING_TAG: pinned build id (e.g. `151.0.7922.47`), `stable`, or
+ * `latest` (canary). Defaults to `latest` when unset.
  * Cache: E2E_CFT_CACHE_DIR or ~/.cache/mini-mealie-chrome-for-testing.
  */
 import { spawnSync } from 'node:child_process';

--- a/e2e-shared/support-range.json
+++ b/e2e-shared/support-range.json
@@ -3,5 +3,9 @@
         "repository": "ghcr.io/mealie-recipes/mealie",
         "oldest": "v3.19.2",
         "newest": "v3.20.1"
+    },
+    "chrome": {
+        "oldest": "149.0.7827.155",
+        "newest": "151.0.7922.47"
     }
 }

--- a/e2e-shared/support-range.ts
+++ b/e2e-shared/support-range.ts
@@ -4,14 +4,23 @@ import path from 'node:path';
 import { REPO_ROOT } from './config';
 
 /**
- * Supported Mealie ends for the PR e2e gate.
+ * Supported Mealie / Chrome ends for the PR e2e gate.
  * Source of truth: `e2e-shared/support-range.json`.
- * Raising `mealie.oldest` is an intentional, documented change.
+ * Raising any `*.oldest` field is an intentional, documented change.
+ *
+ * Chrome ends are pinned Chrome for Testing build ids (not Playwright’s bundled
+ * Chromium). Canary still floats `latest` and is not stored in this file.
  */
 export type SupportRange = {
     mealie: {
         repository: string;
         oldest: string;
+        newest: string;
+    };
+    chrome: {
+        /** Pinned CfT build for the oldest supported Chrome (backward-compat floor). */
+        oldest: string;
+        /** Pinned CfT Stable build for the newest supported Chrome. */
         newest: string;
     };
 };


### PR DESCRIPTION
## Summary
- Extend `support-range.json` with pinned Chrome for Testing ends: `149.0.7827.155` … `151.0.7922.47` (newest − 2 milestones … current Stable).
- PR gate adds `chrome-oldest` and `chrome-newest` (Mealie on newest pin; Firefox skipped; both legs install CfT + smoke).
- Mealie legs still use Playwright Chromium as the harness default (not a support-range end). Canary still floats CfT `latest` only — not a third pin in the JSON.
- Docs: Chrome range, no branded Google Chrome in CI, gate vs canary.

Implements #197 (parent #193).

## Design note vs issue text
Issue #197 originally proposed `chrome.oldest: "playwright"`. For real backward-compat both ends need **explicit CfT build pins** — Playwright Chromium is harness-only and moves with package bumps, so it is a poor floor. This PR follows the corrected rule used on the fork: oldest = latest build of newest − 2 milestones; newest = verified Stable.

## Merge order
1. #195 (Chrome for Testing canary)
2. #200 (Mealie support range — this branch is stacked on it)
3. **this PR**

## Test plan
- [ ] PR E2E shows `chrome-oldest` (CfT 149…) and `chrome-newest` (CfT 151… + smoke); Firefox skipped on both
- [ ] `mealie-oldest` / `mealie-newest` still run Playwright Chromium + Firefox
- [ ] Canary `chrome-latest` still installs CfT `@latest`
- [ ] Raising `chrome.oldest` / `chrome.newest` is only via editing the JSON

Closes #197