### PR TITLE
ci(e2e): gate PRs on Firefox oldest and newest pins

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -12,7 +12,7 @@ on:
                 type: string
                 required: false
             firefox_version:
-                description: 'Firefox version for setup.sh (empty → pinned FIREFOX_VER; "latest" for newest)'
+                description: 'Firefox version for setup.sh (empty → firefox.newest from support-range.json; "latest" for canary)'
                 type: string
                 required: false
             chrome_version:
@@ -30,7 +30,7 @@ on:
                 type: string
                 required: false
             firefox_version:
-                description: 'Firefox version for setup.sh (empty → the pinned FIREFOX_VER; "latest" for newest)'
+                description: 'Firefox version for setup.sh (empty → firefox.newest from support-range.json; "latest" for canary)'
                 type: string
                 required: false
             chrome_version:
@@ -54,8 +54,8 @@ env:
 jobs:
     chrome:
         name: Chrome MV3
-        # Skip on the canary's firefox-latest leg: Chrome never reads FIREFOX_VER, so that run
-        # would be identical to the pinned PR-gate Chrome job (wasted CI, no new signal).
+        # Skip on firefox-oldest / firefox-newest / firefox-latest: Chrome never reads
+        # FIREFOX_VER, so that run would duplicate a mealie-* / chrome-* Chrome job.
         # Empty/unset (mealie-*) / CfT pin / chrome-latest → Chrome still runs.
         if: ${{ !inputs.firefox_version }}
         runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,11 @@ name: E2E
 # PR gate: prove both ends of each declared support range (see e2e-shared/support-range.json).
 # One moving piece per leg — not a cartesian product across Mealie × Chrome × Firefox.
 #
-# Mealie legs: both browsers on current pins (Playwright Chromium + pinned Firefox).
+# Mealie legs: Playwright Chromium + Firefox newest pin.
 # Chrome legs: Mealie on newest pin; Firefox skipped. Both ends are pinned Chrome for Testing
 # builds (oldest = newest − 2 milestones) so the gate proves backward compatibility.
+# Firefox legs: Mealie on newest pin; Chrome skipped. Both ends from support-range.json
+# (oldest = newest − 2 majors).
 #
 # Gate vs canary: this workflow proves the declared support range. e2e-canary.yml watches
 # brand-new upstream `:latest` / `latest` releases (non-blocking early warning).
@@ -30,6 +32,8 @@ jobs:
             mealie_newest: ${{ steps.range.outputs.mealie_newest }}
             chrome_oldest: ${{ steps.range.outputs.chrome_oldest }}
             chrome_newest: ${{ steps.range.outputs.chrome_newest }}
+            firefox_oldest: ${{ steps.range.outputs.firefox_oldest }}
+            firefox_newest: ${{ steps.range.outputs.firefox_newest }}
         steps:
             - name: Checkout Code
               uses: actions/checkout@v7
@@ -42,14 +46,19 @@ jobs:
                   newest=$(jq -r '.mealie.newest' e2e-shared/support-range.json)
                   chrome_oldest=$(jq -r '.chrome.oldest' e2e-shared/support-range.json)
                   chrome_newest=$(jq -r '.chrome.newest' e2e-shared/support-range.json)
+                  firefox_oldest=$(jq -r '.firefox.oldest' e2e-shared/support-range.json)
+                  firefox_newest=$(jq -r '.firefox.newest' e2e-shared/support-range.json)
                   echo "mealie_oldest=${oldest}" >> "$GITHUB_OUTPUT"
                   echo "mealie_newest=${newest}" >> "$GITHUB_OUTPUT"
                   echo "mealie_oldest_image=${repo}:${oldest}" >> "$GITHUB_OUTPUT"
                   echo "mealie_newest_image=${repo}:${newest}" >> "$GITHUB_OUTPUT"
                   echo "chrome_oldest=${chrome_oldest}" >> "$GITHUB_OUTPUT"
                   echo "chrome_newest=${chrome_newest}" >> "$GITHUB_OUTPUT"
+                  echo "firefox_oldest=${firefox_oldest}" >> "$GITHUB_OUTPUT"
+                  echo "firefox_newest=${firefox_newest}" >> "$GITHUB_OUTPUT"
                   echo "Mealie support range: ${oldest} … ${newest}"
                   echo "Chrome support range: ${chrome_oldest} … ${chrome_newest}"
+                  echo "Firefox support range: ${firefox_oldest} … ${firefox_newest}"
 
     mealie-oldest:
         name: mealie-oldest (${{ needs.resolve.outputs.mealie_oldest }})
@@ -86,3 +95,23 @@ jobs:
             mealie_image: ${{ needs.resolve.outputs.mealie_newest_image }}
             chrome_version: ${{ needs.resolve.outputs.chrome_newest }}
             run_label: chrome-newest
+
+    # Both Firefox ends: pinned non-snap releases. Setting firefox_version skips Chrome
+    # (same skip idea as firefox-latest canary) so this leg only moves the browser.
+    firefox-oldest:
+        name: firefox-oldest (${{ needs.resolve.outputs.firefox_oldest }})
+        needs: resolve
+        uses: ./.github/workflows/e2e-suite.yml
+        with:
+            mealie_image: ${{ needs.resolve.outputs.mealie_newest_image }}
+            firefox_version: ${{ needs.resolve.outputs.firefox_oldest }}
+            run_label: firefox-oldest
+
+    firefox-newest:
+        name: firefox-newest (${{ needs.resolve.outputs.firefox_newest }})
+        needs: resolve
+        uses: ./.github/workflows/e2e-suite.yml
+        with:
+            mealie_image: ${{ needs.resolve.outputs.mealie_newest_image }}
+            firefox_version: ${{ needs.resolve.outputs.firefox_newest }}
+            run_label: firefox-newest

--- a/docs/developers-guide/e2e-testing.md
+++ b/docs/developers-guide/e2e-testing.md
@@ -89,31 +89,36 @@ pnpm test:e2e:down
 | `E2E_FIXTURE_PORT` | `8730` | port for the local fixture server |
 | `MEALIE_IMAGE` / `MEALIE_PORT` | newest from `support-range.json` / `9925` | Docker Mealie image / host port |
 | `E2E_FIREFOX_XPI` | newest `.output/*-firefox.zip` | Firefox add-on to install |
-| `FIREFOX_VER` | `142.0` (pinned) | Firefox version `setup.sh` fetches; set `latest` for the canary |
+| `FIREFOX_VER` | newest from `support-range.json` | Firefox version `setup.sh` fetches; set `latest` for the canary |
+| `GECKO_VER` | `firefox.geckodriver` from `support-range.json` | geckodriver release tag |
 | `PLAYWRIGHT_CHROME_EXECUTABLE` | (unset → Playwright Chromium) | absolute path to Chrome for Testing |
 | `CHROME_FOR_TESTING_TAG` | `latest` | tag / build id for `@puppeteer/browsers` (`151.0.7922.47`, `stable`, `latest`, …) |
 | `E2E_HEADLESS` | on | set `0` to watch Firefox run |
 
 ## Support range
 
-`e2e-shared/support-range.json` is the **single source of truth** for which Mealie and Chrome
-ends we claim to support. Local `pnpm test:e2e:up` uses **newest** Mealie when `MEALIE_IMAGE`
-is unset. Compose requires `MEALIE_IMAGE` — always go through the harness or set it yourself
-from that file.
+`e2e-shared/support-range.json` is the **single source of truth** for which Mealie, Chrome,
+and Firefox ends we claim to support. Local `pnpm test:e2e:up` uses **newest** Mealie when
+`MEALIE_IMAGE` is unset; `setup.sh` / the Firefox harness use **newest** Firefox when
+`FIREFOX_VER` is unset. Compose requires `MEALIE_IMAGE` — always go through the harness or
+set it yourself from that file.
 
-| End | Mealie | Chrome (CfT) | Rolling rule |
-| --- | --- | --- | --- |
-| **Oldest** | `v3.19.2` | `149.0.7827.155` | Mealie: latest patch of **newest − 2 minors**. Chrome: latest build of **newest − 2 milestones**. |
-| **Newest** | `v3.20.1` | `151.0.7922.47` | Latest stable the gate (or a bump PR) has proven green |
+| End | Mealie | Chrome (CfT) | Firefox | Rolling rule |
+| --- | --- | --- | --- | --- |
+| **Oldest** | `v3.19.2` | `149.0.7827.155` | `151.0` | Mealie: latest patch of **newest − 2 minors**. Chrome: latest build of **newest − 2 milestones**. Firefox: **newest − 2 majors**. |
+| **Newest** | `v3.20.1` | `151.0.7922.47` | `153.0` | Latest stable the gate (or a bump PR) has proven green |
+
+`firefox.geckodriver` (`v0.37.1`) is pinned alongside the Firefox range — Firefox 153+ needs
+geckodriver ≥ 0.37.1 for `--allow-system-access`. `wxt.config.ts` `strict_min_version` must
+match `firefox.oldest`.
 
 Raising any `*.oldest` field is an intentional change: edit the JSON and say so in the PR /
-release notes. Do not raise a floor as a side effect of chasing “latest.” Firefox still uses a
-single pin; its support-range fields land under
-[#198](https://github.com/mrshappy0/mini-mealie/issues/198).
+release notes. Do not raise a floor as a side effect of chasing “latest.”
 
 **No branded Google Chrome in CI.** Store Chrome removed the flags needed to side-load unpacked
 extensions. Gate Chrome range legs and the canary use **Chrome for Testing** only. Mealie legs
 still use Playwright’s bundled Chromium as the harness default (not a support-range end).
+**ESR** is out of the default Firefox range unless we explicitly decide to support it.
 
 ## CI (PR gate)
 
@@ -123,13 +128,16 @@ still use Playwright’s bundled Chromium as the harness default (not a support-
 
 | Leg | Mealie | Chrome | Firefox |
 | --- | --- | --- | --- |
-| `mealie-oldest` | oldest tag | Playwright Chromium | pinned `142.0` |
-| `mealie-newest` | newest tag | Playwright Chromium | pinned `142.0` |
+| `mealie-oldest` | oldest tag | Playwright Chromium | newest pin (`153.0`) |
+| `mealie-newest` | newest tag | Playwright Chromium | newest pin (`153.0`) |
 | `chrome-oldest` | newest tag | CfT `149.0.7827.155` | skipped |
 | `chrome-newest` | newest tag | CfT `151.0.7922.47` | skipped |
+| `firefox-oldest` | newest tag | skipped | `151.0` |
+| `firefox-newest` | newest tag | skipped | `153.0` |
 
 One moving piece per leg (same idea as the canary) — not a full Mealie × browser grid.
-`chrome-*` legs skip Firefox so a red check names the browser, not a duplicate Firefox run.
+`chrome-*` legs skip Firefox and `firefox-*` legs skip Chrome so a red check names the
+browser, not a duplicate run.
 
 - Docker + Compose ship on `ubuntu-latest`, so `test:e2e:up` brings up Mealie there exactly
   as it does locally.
@@ -138,7 +146,8 @@ One moving piece per leg (same idea as the canary) — not a full Mealie × brow
 - Chrome uses the self-contained `pnpm test:e2e`; Firefox adds the `setup.sh` step.
 - **Pinned ends** so the gate is deterministic — a red PR means *your* change broke something
   in the support range, not that an upstream dep just shipped: Mealie (`oldest`…`newest`),
-  Chrome (pinned CfT oldest…newest), Firefox (`142.0`), geckodriver (`v0.36.0`).
+  Chrome (pinned CfT oldest…newest), Firefox (pinned oldest…newest), geckodriver
+  (`firefox.geckodriver`).
 
 ## Canary (early warning)
 
@@ -155,9 +164,9 @@ names the culprit:
 
 | Leg | Overrides | Pinned | Jobs |
 | --- | --- | --- | --- |
-| `mealie-latest` | Mealie → `:latest` | Firefox `142.0`, Playwright Chromium | Chrome + Firefox |
+| `mealie-latest` | Mealie → `:latest` | Firefox newest pin, Playwright Chromium | Chrome + Firefox |
 | `firefox-latest` | Firefox → `latest` (also catches geckodriver/Firefox skew) | Mealie newest pin | Firefox only |
-| `chrome-latest` | Chrome for Testing → `latest` via `PLAYWRIGHT_CHROME_EXECUTABLE` | Mealie newest pin, Firefox `142.0`, Playwright version | Chrome only |
+| `chrome-latest` | Chrome for Testing → `latest` via `PLAYWRIGHT_CHROME_EXECUTABLE` | Mealie newest pin, Firefox newest pin, Playwright version | Chrome only |
 
 `chrome-latest` keeps Playwright pinned and downloads **Chrome for Testing** `@latest`
 (`pnpm test:e2e:chrome-cft:install`), then drives it with `executablePath`. Branded Google Chrome
@@ -180,8 +189,9 @@ duplicate a gate Chrome run). The `chrome-latest` leg runs **only** the Chrome j
 To run on your own server instead of GitHub-hosted, change `runs-on` to `[self-hosted]` —
 just ensure Docker is installed and the runner user is in the `docker` group. On a persistent
 runner, "latest" can go stale without care: Firefox is cached under a **version-keyed** directory
-(`~/.local/firefox-nonsnap-$FIREFOX_VER`), and `FIREFOX_VER=latest` always re-downloads; Chrome for
-Testing is cached under `~/.cache/mini-mealie-chrome-for-testing` (clear it to force a refresh);
-Mealie `compose` **pulls** only for floating `:latest` images so the canary refreshes.
+(`~/.local/firefox-nonsnap-$FIREFOX_VER`), and `FIREFOX_VER=latest` always re-downloads;
+geckodriver is reinstalled when the pin in `support-range.json` moves; Chrome for Testing is
+cached under `~/.cache/mini-mealie-chrome-for-testing` (clear it to force a refresh); Mealie
+`compose` **pulls** only for floating `:latest` images so the canary refreshes.
 GitHub-hosted `ubuntu-latest` is a fresh VM each run, so this only matters for self-hosted.
 The harnesses stay excluded from lint / tsc / vitest and from the AMO sources zip.

--- a/e2e-geckodriver/firefox-e2e.ts
+++ b/e2e-geckodriver/firefox-e2e.ts
@@ -19,6 +19,7 @@ import {
 } from '../e2e-shared/config';
 import { startFixtureServer, stopFixtureServer } from '../e2e-shared/fixture-server';
 import { waitForRecipe } from '../e2e-shared/mealie-api';
+import { defaultFirefoxVersion } from '../e2e-shared/support-range';
 
 /**
  * Firefox MV2 E2E via Selenium + geckodriver.
@@ -36,8 +37,9 @@ loadE2eEnv();
 
 const HOME = os.homedir();
 // Must match e2e-geckodriver/setup.sh's version-keyed default
-// (~/.local/firefox-nonsnap-$FIREFOX_VER). Override with E2E_FIREFOX_BIN if needed.
-const FIREFOX_VER = process.env.FIREFOX_VER?.trim() || '142.0';
+// (~/.local/firefox-nonsnap-$FIREFOX_VER). Empty → firefox.newest from support-range.json.
+// Override with E2E_FIREFOX_BIN if needed.
+const FIREFOX_VER = process.env.FIREFOX_VER?.trim() || defaultFirefoxVersion();
 const FIREFOX_BIN =
     process.env.E2E_FIREFOX_BIN?.trim() ||
     path.join(HOME, `.local/firefox-nonsnap-${FIREFOX_VER}`, 'firefox', 'firefox');
@@ -62,7 +64,8 @@ async function buildDriver(): Promise<WebDriver> {
     options.setPreference('extensions.langpacks.signatures.required', false);
 
     // Firefox 153+ blocks WebDriver navigation to moz-extension:// pages unless
-    // geckodriver opts into parent-process access. Harmless on older pins (142).
+    // geckodriver opts into parent-process access. Harmless on older pins (151).
+    // Requires geckodriver ≥ 0.37.1 (see firefox.geckodriver in support-range.json).
     // https://firefox-source-docs.mozilla.org/testing/geckodriver/Flags.html#allow-system-access
     const service = new ServiceBuilder(GECKODRIVER_BIN).addArguments('--allow-system-access');
     return new Builder().forBrowser('firefox').setFirefoxOptions(options).setFirefoxService(service).build();

--- a/e2e-geckodriver/setup.sh
+++ b/e2e-geckodriver/setup.sh
@@ -3,13 +3,28 @@
 # Fetches a NON-SNAP Firefox + geckodriver — snap Firefox is sandboxed and can't be
 # driven by geckodriver. Idempotent: re-running only fetches what's missing.
 #
+# Defaults for FIREFOX_VER / GECKO_VER come from e2e-shared/support-range.json
+# (firefox.newest / firefox.geckodriver). The canary sets FIREFOX_VER=latest.
 # The Selenium client itself is an npm devDependency (selenium-webdriver), so no pip here.
 set -euo pipefail
 
-GECKO_VER=${GECKO_VER:-v0.36.0}
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RANGE_JSON="$REPO_ROOT/e2e-shared/support-range.json"
+
+read_range() {
+    # $1 = dotted path under the JSON root (e.g. firefox.newest)
+    node -e "
+        const r = require('$RANGE_JSON');
+        const v = '$1'.split('.').reduce((o, k) => o[k], r);
+        if (v == null || v === '') process.exit(1);
+        process.stdout.write(String(v));
+    "
+}
+
+GECKO_VER=${GECKO_VER:-$(read_range firefox.geckodriver)}
 # Pin Firefox so the PR gate is deterministic (a red run means your change broke, not that
-# Firefox shipped a release). The canary sets FIREFOX_VER=latest for early-warning signal.
-FIREFOX_VER=${FIREFOX_VER:-142.0}
+# Firefox shipped a release). Empty/unset → newest from support-range.json.
+FIREFOX_VER=${FIREFOX_VER:-$(read_range firefox.newest)}
 # Version-keyed cache dir so pinned and canary installs don't clobber each other on a
 # persistent (self-hosted) runner. Override with FIREFOX_DIR if you need a fixed path.
 FIREFOX_DIR=${FIREFOX_DIR:-$HOME/.local/firefox-nonsnap-$FIREFOX_VER}
@@ -19,7 +34,15 @@ GECKO_BIN=${GECKO_BIN:-$HOME/.local/bin/geckodriver}
 tmp='' ff_tmp=''
 trap 'rm -rf "${tmp:-}" "${ff_tmp:-}"' EXIT
 
+gecko_needs_install=0
 if [[ ! -x "$GECKO_BIN" ]]; then
+    gecko_needs_install=1
+elif ! "$GECKO_BIN" --version 2>/dev/null | grep -qF "${GECKO_VER#v}"; then
+    # Pin moved (e.g. v0.36.0 → v0.37.1); replace the cached binary.
+    gecko_needs_install=1
+fi
+
+if [[ "$gecko_needs_install" -eq 1 ]]; then
     echo "[setup] installing geckodriver $GECKO_VER -> $GECKO_BIN"
     mkdir -p "$(dirname "$GECKO_BIN")"
     tmp=$(mktemp -d)

--- a/e2e-shared/support-range.json
+++ b/e2e-shared/support-range.json
@@ -7,5 +7,10 @@
     "chrome": {
         "oldest": "149.0.7827.155",
         "newest": "151.0.7922.47"
+    },
+    "firefox": {
+        "oldest": "151.0",
+        "newest": "153.0",
+        "geckodriver": "v0.37.1"
     }
 }

--- a/e2e-shared/support-range.ts
+++ b/e2e-shared/support-range.ts
@@ -4,12 +4,13 @@ import path from 'node:path';
 import { REPO_ROOT } from './config';
 
 /**
- * Supported Mealie / Chrome ends for the PR e2e gate.
+ * Supported Mealie / Chrome / Firefox ends for the PR e2e gate.
  * Source of truth: `e2e-shared/support-range.json`.
  * Raising any `*.oldest` field is an intentional, documented change.
  *
  * Chrome ends are pinned Chrome for Testing build ids (not Playwright’s bundled
- * Chromium). Canary still floats `latest` and is not stored in this file.
+ * Chromium). Firefox ends are non-snap release tags fetched by `setup.sh`.
+ * Canary still floats `latest` / `:latest` and is not stored in this file.
  */
 export type SupportRange = {
     mealie: {
@@ -22,6 +23,14 @@ export type SupportRange = {
         oldest: string;
         /** Pinned CfT Stable build for the newest supported Chrome. */
         newest: string;
+    };
+    firefox: {
+        /** Oldest Firefox release we still claim to support (newest − 2 majors). */
+        oldest: string;
+        /** Newest Firefox release the gate has proven green. */
+        newest: string;
+        /** geckodriver release tag paired with the Firefox range (e.g. `v0.37.1`). */
+        geckodriver: string;
     };
 };
 
@@ -42,4 +51,14 @@ export function mealieImageFor(tag: string, range = loadSupportRange()): string 
 /** Default local / unset-env Mealie image: newest end of the support range. */
 export function defaultMealieImage(range = loadSupportRange()): string {
     return mealieImageFor(range.mealie.newest, range);
+}
+
+/** Default local / unset-env Firefox version: newest end of the support range. */
+export function defaultFirefoxVersion(range = loadSupportRange()): string {
+    return range.firefox.newest;
+}
+
+/** geckodriver release tag from the support file. */
+export function defaultGeckodriverVersion(range = loadSupportRange()): string {
+    return range.firefox.geckodriver;
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -48,7 +48,8 @@ export default defineConfig({
                           // Required for chrome.storage.sync / browser.storage.sync under temporary
                           // loads (about:debugging). Without an explicit ID, Firefox disables sync storage.
                           id: 'mini-mealie@shaplabs.net',
-                          strict_min_version: '142.0',
+                          // Keep in sync with firefox.oldest in e2e-shared/support-range.json.
+                          strict_min_version: '151.0',
                           // Mozilla AMO policy (effective 2025-11-03): every new add-on must
                           // declare what data leaves the browser. This extension sends the
                           // user-supplied Mealie API token (authenticationInfo) and the active


### PR DESCRIPTION
## Summary
- Extend `support-range.json` with Firefox ends: `151.0` … `153.0` (newest − 2 majors … verified Stable) plus `geckodriver: v0.37.1`.
- PR gate adds `firefox-oldest` and `firefox-newest` (Mealie on newest pin; Chrome skipped).
- `setup.sh` / `firefox-e2e.ts` defaults read the JSON (catch-up from hardcoded `142.0` / geckodriver `v0.36.0`).
- Align `wxt.config.ts` `strict_min_version` with `firefox.oldest`.
- Canary still floats Firefox `latest` only.

Implements #198 (parent #193).

## Merge order
1. #194 (geckodriver `--allow-system-access` — required for Firefox 153)
2. #195 → #200 → #201
3. **this PR**

This branch cherry-picks the same `--allow-system-access` change as #194 so Firefox 153 CI is green before #194 lands. Once #194 is on `main`, rebase drops that duplicate commit.

## Test plan
- [ ] PR E2E shows `firefox-oldest (151.0)` and `firefox-newest (153.0)`; Chrome skipped on both
- [ ] `mealie-*` legs use Firefox newest pin from the JSON (not hardcoded 142)
- [ ] `strict_min_version` is `151.0`
- [ ] Canary `firefox-latest` still floats `latest`
- [ ] Raising `firefox.oldest` is only via editing the JSON (+ matching `strict_min_version`)

Closes #198