### PR TITLE
docs: point README readers at the support range

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ Mini Mealie is a browser extension built using WXT and React, designed to speed 
     - **React** v19.x
     - **TypeScript** 5.9.x
 
+### Supported versions
+
+Every pull request is tested against both ends of a declared range for
+**Mealie**, **Chrome**, and **Firefox** (so raising the newest pin cannot
+quietly drop an older version people still run).
+
+Current pins live in
+[`e2e-shared/support-range.json`](e2e-shared/support-range.json).
+Rolling rules and how the PR gate differs from the weekly canary are in the
+[e2e testing guide](docs/developers-guide/e2e-testing.md#support-range).
+
 ---
 
 ## Installation and Setup


### PR DESCRIPTION
## Summary
- Add a short **Supported versions** section to `README.md` so self-hosters see that we claim a Mealie / Chrome / Firefox range.
- Links to `e2e-shared/support-range.json` (current pins) and the e2e guide support-range section (rolling rules, gate vs canary).
- No duplicated version numbers in the README — pins stay in the JSON only.

Implements #199 (parent #193).

## Merge order
Merge after the range PRs so the linked files exist on `main`:
1. #195 → #200 → #201 → #202
2. **this PR**

(Safe to land anytime after #200 if you only need the Mealie JSON + docs anchor; the README text mentions all three browsers.)

## Test plan
- [ ] README “Supported versions” section renders with working relative links
- [ ] Links resolve to `e2e-shared/support-range.json` and `docs/developers-guide/e2e-testing.md#support-range`
- [ ] No version numbers duplicated in the README

Closes #199