### PR TITLE
fix(security): patch brace-expansion DoS (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   firefox-profile>adm-zip: '>=0.6.0'
   undici: '>=7.28.0'
   fast-uri: '>=3.1.4'
+  minimatch@10.2.5>brace-expansion: '>=5.0.8'
 
 packageExtensionsChecksum: sha256-xx97ir72Z/Od9tONlIEsbEVKGUrhc6tGfUeweqcsMOk=
 
@@ -1305,9 +1306,9 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5428,7 +5429,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7034,7 +7035,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,21 @@ allowBuilds:
     esbuild: true
     spawn-sync: true
 
+auditConfig:
+    ignoreGhsas:
+        # GHSA-mh99-v99m-4gvg: brace-expansion DoS, patched only at 5.0.8+.
+        # Remaining instance is brace-expansion@1.1.16 via minimatch@3.1.5
+        # (eslint-plugin-react, and multimatch → web-ext-run → wxt). minimatch@3.1.5
+        # calls brace-expansion as `require('brace-expansion')(str)`; 5.0.8 exports
+        # `{ expand }` instead, so forcing the upgrade breaks those callers (verified:
+        # eslint-plugin-react's minimatch-based rules call it the same way). No
+        # minimatch release backports the fix while keeping the old call shape.
+        # devDependency-only: both callers match our own lint/build-time glob
+        # patterns, never attacker-controlled input. The minimatch@10.2.5 instance
+        # (below) is fixed directly. Revisit if eslint-plugin-react or multimatch
+        # ship a minimatch@9+ upgrade.
+        - GHSA-mh99-v99m-4gvg
+
 minimumReleaseAgeExclude:
     - '@eslint/css@1.4.0'
     - '@types/chrome@0.2.1'
@@ -40,6 +55,10 @@ overrides:
     # authority delimiter in versions <=3.1.3. Transitive via
     # @commitlint → ajv (no newer commitlint pin yet).
     fast-uri: '>=3.1.4'
+    # GHSA-mh99-v99m-4gvg: brace-expansion DoS, patched at 5.0.8. minimatch@10.2.5
+    # already calls the modern `{ expand }` API, so bumping here is a safe, direct
+    # fix (see auditConfig.ignoreGhsas above for the other, incompatible instance).
+    'minimatch@10.2.5>brace-expansion': '>=5.0.8'
 
 packageExtensions:
     'minimatch@10.2.5':


### PR DESCRIPTION
## Summary
- Bumps `brace-expansion` to `5.0.8` (patched) under the `minimatch@10.2.5` chain, which already uses the modern `{ expand }` API — a direct, safe fix.
- The other instance (`brace-expansion@1.1.16` via `minimatch@3.1.5`, used by `eslint-plugin-react` and `multimatch`/`web-ext-run`/`wxt`) can't take the same fix: those callers do `require('brace-expansion')(str)` directly, but `5.0.8` only exports `{ expand }` — forcing the upgrade breaks linting and the extension zip step (verified). No `minimatch` release backports the patch while keeping the old call shape.
- That remaining instance is devDependency-only — both callers only ever match our own lint/build-time glob patterns, never attacker-controlled input — so it's recorded as an accepted, documented risk via `auditConfig.ignoreGhsas` in `pnpm-workspace.yaml`, rather than left silently unaddressed.

Closes #204, closes #205.

## Test plan
- [x] `pnpm audit` exits 0 (1 vulnerability ignored with documented rationale)
- [x] `pnpm lint`, `pnpm typecheck`, full unit suite (196 tests) all pass unchanged
- [x] `pnpm build` / `pnpm build:firefox` and `pnpm zip` / `pnpm zip:firefox` succeed (exercises the untouched `minimatch@3.1.5` chain via web-ext-run)