### PR TITLE
refactor: migrate start/success/failure logging to withOperation()

### DIFF
--- a/utils/invoke.ts
+++ b/utils/invoke.ts
@@ -59,38 +59,30 @@ export function runCreateRecipe(tab: chrome.tabs.Tab) {
                         return;
                     }
 
+                    const tabUrl = tab.url;
                     await beginActivity('Creating recipe (URL)');
-                    void logEvent({
-                        level: 'info',
-                        feature: 'recipe-create',
-                        action: 'createFromUrl',
-                        phase: 'start',
-                        message: 'Creating recipe from URL',
-                        data: { url: sanitizeUrl(tab.url) },
-                    });
 
-                    const result = await createRecipeFromURL(
-                        tab.url,
-                        mealieServer,
-                        mealieApiToken,
-                        importTags ?? true,
-                        importCategories ?? true,
+                    const result = await withOperation(
+                        {
+                            feature: 'recipe-create',
+                            action: 'createFromUrl',
+                            message: 'Creating recipe from URL',
+                            data: { url: sanitizeUrl(tabUrl) },
+                        },
+                        () =>
+                            createRecipeFromURL(
+                                tabUrl,
+                                mealieServer,
+                                mealieApiToken,
+                                importTags ?? true,
+                                importCategories ?? true,
+                            ),
+                        (res) => res !== 'failure',
                     );
                     const success = result !== 'failure';
 
-                    void logEvent({
-                        level: success ? 'info' : 'warn',
-                        feature: 'recipe-create',
-                        action: 'createFromUrl',
-                        phase: success ? 'success' : 'failure',
-                        message: success
-                            ? 'Recipe created from URL'
-                            : 'Failed to create recipe from URL',
-                        data: { url: sanitizeUrl(tab.url) },
-                    });
-
                     if (success) {
-                        invalidateDetectionCacheForUrl(tab.url);
+                        invalidateDetectionCacheForUrl(tabUrl);
                     }
 
                     await endActivity(
@@ -117,67 +109,53 @@ export function runCreateRecipe(tab: chrome.tabs.Tab) {
                         return;
                     }
 
+                    const tabId = tab.id;
+                    const tabUrl = tab.url;
                     await beginActivity('Creating recipe (HTML)');
-                    void logEvent({
-                        level: 'info',
-                        feature: 'html-capture',
-                        action: 'getPageHTML',
-                        phase: 'start',
-                        message: 'Capturing page HTML',
-                        data: { url: tab.url ? sanitizeUrl(tab.url) : undefined },
-                    });
 
-                    const html = await getPageHTML(tab.id);
-                    if (!html) {
-                        void logEvent({
-                            level: 'warn',
+                    const htmlData: { url?: string; htmlLength?: number } = {
+                        url: tabUrl ? sanitizeUrl(tabUrl) : undefined,
+                    };
+                    const html = await withOperation(
+                        {
                             feature: 'html-capture',
                             action: 'getPageHTML',
-                            phase: 'failure',
-                            message: 'Failed to capture page HTML',
-                        });
+                            message: 'Capturing page HTML',
+                            data: htmlData,
+                        },
+                        async () => {
+                            const captured = await getPageHTML(tabId);
+                            if (captured) {
+                                htmlData.htmlLength = captured.length;
+                            }
+                            return captured;
+                        },
+                        (captured) => captured !== null,
+                    );
+                    if (!html) {
                         await endActivity('❌', 'Failed to capture page HTML');
                         return;
                     }
 
-                    void logEvent({
-                        level: 'info',
-                        feature: 'html-capture',
-                        action: 'getPageHTML',
-                        phase: 'success',
-                        message: 'Page HTML captured',
-                        data: { htmlLength: html.length },
-                    });
-
-                    void logEvent({
-                        level: 'info',
-                        feature: 'recipe-create',
-                        action: 'createFromHtml',
-                        phase: 'start',
-                        message: 'Creating recipe from HTML',
-                        data: { url: tab.url ? sanitizeUrl(tab.url) : undefined },
-                    });
-
-                    const result = await createRecipeFromHTML(
-                        html,
-                        mealieServer,
-                        mealieApiToken,
-                        tab.url,
-                        importTags ?? true,
-                        importCategories ?? true,
+                    const result = await withOperation(
+                        {
+                            feature: 'recipe-create',
+                            action: 'createFromHtml',
+                            message: 'Creating recipe from HTML',
+                            data: { url: tabUrl ? sanitizeUrl(tabUrl) : undefined },
+                        },
+                        () =>
+                            createRecipeFromHTML(
+                                html,
+                                mealieServer,
+                                mealieApiToken,
+                                tabUrl,
+                                importTags ?? true,
+                                importCategories ?? true,
+                            ),
+                        (res) => res !== 'failure',
                     );
                     const success = result !== 'failure';
-
-                    void logEvent({
-                        level: success ? 'info' : 'warn',
-                        feature: 'recipe-create',
-                        action: 'createFromHtml',
-                        phase: success ? 'success' : 'failure',
-                        message: success
-                            ? 'Recipe created from HTML'
-                            : 'Failed to create recipe from HTML',
-                        data: { url: tab.url ? sanitizeUrl(tab.url) : undefined },
-                    });
 
                     await endActivity(
                         success ? '✅' : '❌',

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -198,65 +198,50 @@ export const getUser = async (
     url: string,
     token: string,
 ): Promise<User | { errorMessage: string }> => {
-    const { logEvent, sanitizeUrl } = await import('./logging');
+    const { withOperation, sanitizeUrl } = await import('./logging');
 
-    await logEvent({
-        level: 'info',
-        feature: 'auth',
-        action: 'getUser',
-        phase: 'start',
-        message: 'Fetching user profile',
-        data: { server: sanitizeUrl(normalizeMealieServerBaseUrl(url)) },
-    });
+    const base = normalizeMealieServerBaseUrl(url);
+    const data: { server: string; username?: string } = { server: sanitizeUrl(base) };
 
     try {
-        const base = normalizeMealieServerBaseUrl(url);
-        const authToken = token.trim();
-
-        const res = await fetch(`${base}/api/users/self`, {
-            headers: {
-                Authorization: `Bearer ${authToken}`,
-                'Content-Type': 'application/json',
+        return await withOperation(
+            {
+                feature: 'auth',
+                action: 'getUser',
+                message: 'Fetching user profile',
+                data,
             },
-        });
-        if (!res.ok) {
-            throw new Error(`Get User Failed - status: ${res.status}`);
-        }
-        const user = await res.json();
+            async () => {
+                const authToken = token.trim();
 
-        if (
-            !user ||
-            typeof user !== 'object' ||
-            typeof (user as Record<string, unknown>).username !== 'string'
-        ) {
-            return {
-                errorMessage:
-                    'Mealie response did not include a username — check your server URL and Mealie version.',
-            };
-        }
+                const res = await fetch(`${base}/api/users/self`, {
+                    headers: {
+                        Authorization: `Bearer ${authToken}`,
+                        'Content-Type': 'application/json',
+                    },
+                });
+                if (!res.ok) {
+                    throw new Error(`Get User Failed - status: ${res.status}`);
+                }
+                const user = await res.json();
 
-        await logEvent({
-            level: 'info',
-            feature: 'auth',
-            action: 'getUser',
-            phase: 'success',
-            message: 'User profile fetched',
-            data: { server: sanitizeUrl(base), username: (user as User).username },
-        });
+                if (
+                    !user ||
+                    typeof user !== 'object' ||
+                    typeof (user as Record<string, unknown>).username !== 'string'
+                ) {
+                    return {
+                        errorMessage:
+                            'Mealie response did not include a username — check your server URL and Mealie version.',
+                    };
+                }
 
-        return user as User;
+                data.username = (user as User).username;
+                return user as User;
+            },
+            (result) => !('errorMessage' in result),
+        );
     } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-
-        await logEvent({
-            level: 'error',
-            feature: 'auth',
-            action: 'getUser',
-            phase: 'failure',
-            message: `Failed to fetch user: ${errorMessage}`,
-            data: { server: sanitizeUrl(normalizeMealieServerBaseUrl(url)) },
-        });
-
         if (error instanceof Error) {
             return { errorMessage: error.message };
         }

--- a/utils/tests/invoke.test.ts
+++ b/utils/tests/invoke.test.ts
@@ -11,6 +11,7 @@ vi.mock('../activity', () => ({
 vi.mock('../logging', () => ({
     logEvent: vi.fn(),
     sanitizeUrl: vi.fn((url: string) => url),
+    withOperation: vi.fn((_config, fn) => fn()),
 }));
 
 vi.mock('../network', () => ({

--- a/utils/tests/network.test.ts
+++ b/utils/tests/network.test.ts
@@ -36,6 +36,7 @@ vi.mock('../storage', () => ({
 vi.mock('../logging', () => ({
     logEvent: vi.fn(),
     sanitizeUrl: vi.fn((url: string) => url),
+    withOperation: vi.fn((_config, fn) => fn()),
 }));
 
 const mockHtml = '<html><body>Recipe</body></html>';


### PR DESCRIPTION
## Summary
- `invoke.ts` (URL/HTML recipe creation, page HTML capture) and `network.ts`'s `getUser()` hand-rolled the same start-then-success/failure `logEvent` triad that `withOperation()` (restored in #209's follow-up, commit b14000b) already encapsulates — migrated those call sites to use it.
- Checked `storage.ts` and `entrypoints/background.ts` too: they only have single-phase logs (success-only or failure-only guard clauses) with no matching `start` log, so there's no real triad to migrate — left untouched.
- Where a call site logged extra data only available after the operation completed (e.g. `htmlLength`, fetched `username`), the `data` object is passed by reference into `withOperation`'s config and mutated inside `fn()` before it resolves, so the success log still carries that detail.
- Updated the `../logging` mocks in `invoke.test.ts` and `network.test.ts` to include a functional `withOperation` stub (previously only `logEvent`/`sanitizeUrl` were mocked).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (scoped to changed files — a stray locked worktree at `.claude/worktrees/entrypoints-coverage` unrelated to this branch has pre-existing lint/test noise)
- [x] `pnpm test` (196/196 passing, same caveat re: the unrelated worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)