### PR TITLE
fix(ci): submit.yml's secrets-in-if check breaks the whole workflow file

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -13,6 +13,14 @@ jobs:
         name: Submit to Store(s)
         runs-on: ubuntu-latest
         timeout-minutes: 15
+        env:
+            # Mirrored into job-level env because the `secrets` context isn't
+            # allowed in `if:` conditions at all (GitHub rejects the whole
+            # workflow file with "Unrecognized named-value: 'secrets'" if you
+            # reference it there) — only `env` is readable from `if:`. A step's
+            # own `env:` block isn't visible to that same step's `if:`, so this
+            # has to live at the job level for the check below to see it.
+            FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
         steps:
             - name: Checkout Code
               uses: actions/checkout@v7
@@ -48,10 +56,7 @@ jobs:
                   pnpm zip:firefox
 
             - name: Submit to Firefox Add-ons
-              # Check the secret directly: secrets.* is always available at if:
-              # evaluation time, so this doesn't depend on this step's own env:
-              # block having been resolved yet.
-              if: ${{ secrets.FIREFOX_JWT_ISSUER != '' }}
+              if: ${{ env.FIREFOX_JWT_ISSUER != '' }}
               run: |
                   pnpm wxt submit \
                     --firefox-zip .output/*-firefox.zip \
@@ -59,5 +64,4 @@ jobs:
                     --firefox-channel=listed
               env:
                   FIREFOX_EXTENSION_ID: 'mini-mealie@shaplabs.net'
-                  FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
                   FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repo is a **WXT + React** browser extension (MV3). Please optimize for **sm
 
 - WXT drives builds/dev server. Output goes to `.output/`.
 - Extension entrypoints live in `entrypoints/` (popup, background, etc.).
-- Shared logic lives in `utils/` with Vitest coverage focused there.
+- Shared logic lives in `utils/` with Vitest coverage focused there. `entrypoints/**` (popup, logs, background) also has real Vitest coverage now, but isn't part of the enforced coverage gate — see Testing conventions below.
 
 ## Local commands (preferred)
 
@@ -70,6 +70,15 @@ Windows note: if PowerShell blocks `pnpm.ps1`, prefer `pnpm.cmd` or adjust execu
 - Prefer deterministic unit tests (no real network).
 - Add tests alongside existing ones in `utils/tests/`.
 - When changing behavior in `utils/`, update tests in the same PR.
+- `entrypoints/**/tests/` uses jsdom + `@testing-library/react` + `@testing-library/user-event`
+  for component/entrypoint tests. `vitest.setup.ts` bridges fake-browser's promise-only
+  `chrome.storage.*` to the callback style used throughout this codebase, normalizes
+  `chrome.runtime.lastError` to `undefined`, and runs RTL's `cleanup()` after each test.
+- `entrypoints/**` is excluded from the enforced coverage gate (`scripts/check-coverage.sh`):
+  statement coverage reports 0 for these files under both v8 and istanbul providers, a
+  sourcemap-chain issue between WXT's auto-import/JSX transform (or `defineBackground`) and
+  this toolchain. The tests still run and catch regressions — they just don't count toward
+  the gate.
 
 ## Change management
 
@@ -117,5 +126,10 @@ and opens a `tech-debt` labeled issue if so.
 
 ## Undici Security Overrides
 
-`pnpm-workspace.yaml` pins `undici >=7.28.0` to fix 6 open CVEs. This override
-can be removed when `@semantic-release/github` updates its minimum undici version.
+`pnpm-workspace.yaml` scopes two separate `undici` overrides (`>=7.28.0`) to known CVEs
+rather than one blanket override: `@actions/http-client>undici` (real path is
+semantic-release → `@semantic-release/npm` → `@actions/core` → `@actions/http-client`)
+and `jsdom>undici` (capped `<8.0.0`, since jsdom bundles its own `^7.25.0` and a blanket
+override was forcing it to an incompatible major). See the comments in
+`pnpm-workspace.yaml` for the full reasoning; revisit when either dependency chain
+bumps its own undici floor.


### PR DESCRIPTION
## Summary
- `secrets` is not a valid context inside `if:` conditions — GitHub rejects the entire workflow file (`Unrecognized named-value: 'secrets'`) rather than just failing that step. This landed in #208 and has broken `submit.yml` on **every** trigger since (0 jobs spawned per run), including the `release: published` path that actually ships to the Chrome/Firefox stores. Confirmed via the GitHub Actions run history: every push-time evaluation of this workflow has failed with 0 jobs since the commit that introduced `if: ${{ secrets.FIREFOX_JWT_ISSUER != '' }}` landed.
- Fix: mirror `FIREFOX_JWT_ISSUER` into job-level `env:` and check `env.FIREFOX_JWT_ISSUER` in the step's `if:` instead — `env` (unlike `secrets`) is a valid context there, and a job-level `env:` (unlike a step's own) is visible to that step's `if:`.
- Also updated `AGENTS.md`: the entrypoints test infra (jsdom/RTL, coverage-gate exclusion) added in #211 and the narrowed `undici` overrides from the same PR weren't reflected there yet.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/submit.yml'))"` — parses cleanly
- [x] `pnpm lint` — clean
- [ ] After merge: confirm the next push to `main` produces a **successful** (not 0-job) run for `.github/workflows/submit.yml`, and that the next real release actually submits to both stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)