### PR TITLE
chore: move resend to devDependencies and fix placeholder package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mini-mealie",
-    "description": "manifest.json description",
+    "description": "Browser extension that scrapes recipes and saves them to a Mealie instance.",
     "private": true,
     "type": "module",
     "scripts": {
@@ -34,8 +34,7 @@
     "dependencies": {
         "normalize-url": "^9.0.1",
         "react": "^19.2.8",
-        "react-dom": "^19.2.8",
-        "resend": "^6.18.1"
+        "react-dom": "^19.2.8"
     },
     "devDependencies": {
         "@commitlint/cli": "^21.2.0",
@@ -72,6 +71,7 @@
         "jsdom": "^29.1.1",
         "playwright": "^1.62.0",
         "prettier": "^3.9.6",
+        "resend": "^6.18.1",
         "selenium-webdriver": "^4.30.0",
         "semantic-release": "^25.0.8",
         "tsx": "^4.23.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
-      resend:
-        specifier: ^6.18.1
-        version: 6.18.1
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.2.0
@@ -136,6 +133,9 @@ importers:
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
+      resend:
+        specifier: ^6.18.1
+        version: 6.18.1
       selenium-webdriver:
         specifier: ^4.30.0
         version: 4.46.0
@@ -3507,19 +3507,9 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.62.0:
     resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
     engines: {node: '>=20'}
-    hasBin: true
-
-  playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
-    engines: {node: '>=18'}
     hasBin: true
 
   playwright@1.62.0:
@@ -7967,15 +7957,7 @@ snapshots:
       exsolve: 1.1.0
       pathe: 2.0.3
 
-  playwright-core@1.61.1: {}
-
   playwright-core@1.62.0: {}
-
-  playwright@1.61.1:
-    dependencies:
-      playwright-core: 1.61.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.62.0:
     dependencies:


### PR DESCRIPTION
## Summary
- `resend` is only used by `scripts/send-release-email.ts` (the CI release-newsletter job, which installs via the shared setup action with full `pnpm install`) — it's never bundled into the extension. Keeping it in prod `dependencies` skewed `pnpm audit --prod` and misrepresented the runtime surface.
- `package.json` `description` was the literal placeholder "manifest.json description" (the real manifest description lives in `wxt.config.ts`).

## Test plan
- [x] `pnpm install` regenerates lockfile cleanly; `pnpm typecheck`, `pnpm lint`, `pnpm coverage` — 234 tests pass
- [x] `grep -rn resend entrypoints utils components` — no bundled usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)