### PR TITLE
ci(submit): skip the checkout on no-op catch-up runs

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -34,16 +34,16 @@ jobs:
             # has to live at the job level for the checks below to see it.
             FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
         steps:
-            - name: Checkout Code
-              uses: actions/checkout@v7
-              with:
-                  # Full history so the catch-up path can check out the release tag.
-                  fetch-depth: 0
-
+            # Resolving the target and asking each store what it already has is pure HTTP —
+            # no working tree required — so the checkout is deferred until something
+            # actually needs uploading. Most scheduled catch-up runs are no-ops and would
+            # otherwise clone the full history six times a day just to skip every step.
             - name: Resolve target release
               id: target
               env:
                   GH_TOKEN: ${{ github.token }}
+                  # Nothing is checked out yet, so `gh` can't infer the repo from a remote.
+                  GH_REPO: ${{ github.repository }}
               run: |
                   if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
                       TAG="${GITHUB_REF#refs/tags/}"
@@ -121,6 +121,13 @@ jobs:
                       fi
                   fi
                   echo "needed=$NEEDED" >> "$GITHUB_OUTPUT"
+
+            - name: Checkout Code
+              if: steps.chrome.outputs.needed == 'true' || steps.firefox.outputs.needed == 'true'
+              uses: actions/checkout@v7
+              with:
+                  # Full history so the catch-up path can check out the release tag.
+                  fetch-depth: 0
 
             - name: Check out release tag
               if: steps.chrome.outputs.needed == 'true' || steps.firefox.outputs.needed == 'true'


### PR DESCRIPTION
### Background

Run [31121374408](https://github.com/mrshappy0/mini-mealie/actions/runs/31121374408) failed with:

> The job was not acquired by Runner of type hosted even after multiple attempts

That was a GitHub infrastructure hiccup, not a repo problem — the job record shows `steps: []`, so nothing ran. It sat queued for 15 minutes and was cancelled by `timeout-minutes: 15`. No change here addresses that; it was already self-healing.

### What this does change

Looking at the workflow while investigating: the 4-hourly catch-up cron did `actions/checkout` with `fetch-depth: 0` **before** it knew whether either store needed an upload — then skipped every remaining step. The previous 19 scheduled runs were all no-ops, so that's a full-history clone six times a day to make three HTTP calls and quit.

Resolving the target release and querying the Chrome Web Store / AMO need no working tree, so they now run first, and the checkout sits behind the same condition the tag-checkout, setup and build steps already used.

`gh` can no longer infer the repo from a git remote at that point, so `GH_REPO` is passed explicitly.

The upload path is unchanged — same order, same conditions, same full-history checkout when a store actually needs a version. Only the no-op path gets cheaper.

### Not changed

The cron itself stays at 4 hours. It exists because the Chrome Web Store has no webhook to announce that a review finished, so polling is the only mechanism; widening the interval only lengthens how long a release waits during the exact window the cron exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)