### PR TITLE
fix(security): patch js-yaml, fast-uri, and both brace-expansion advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,8 @@ overrides:
   jsdom>undici: '>=7.28.0 <8.0.0'
   fast-uri: '>=4.1.2'
   js-yaml: '>=4.3.1 <5.0.0'
-  minimatch@10.2.5>brace-expansion: '>=5.0.8'
+  minimatch@10.2.5>brace-expansion: '>=5.0.9'
+  minimatch@3.1.5>brace-expansion: '>=1.1.18 <2.0.0'
 
 packageExtensionsChecksum: sha256-xx97ir72Z/Od9tONlIEsbEVKGUrhc6tGfUeweqcsMOk=
 
@@ -1422,11 +1423,11 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -5298,12 +5299,12 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6741,11 +6742,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,8 @@ overrides:
   firefox-profile>adm-zip: '>=0.6.0'
   '@actions/http-client>undici': '>=7.28.0'
   jsdom>undici: '>=7.28.0 <8.0.0'
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
+  js-yaml: '>=4.3.1 <5.0.0'
   minimatch@10.2.5>brace-expansion: '>=5.0.8'
 
 packageExtensionsChecksum: sha256-xx97ir72Z/Od9tONlIEsbEVKGUrhc6tGfUeweqcsMOk=
@@ -2141,8 +2142,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2732,8 +2733,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -5712,7 +5713,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6123,7 +6124,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -6675,7 +6676,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -7217,7 +7218,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,10 +57,21 @@ overrides:
     # jsdom gets its own >=7.28.0 floor below, capped under 8.0.0.
     '@actions/http-client>undici': '>=7.28.0'
     'jsdom>undici': '>=7.28.0 <8.0.0'
-    # GHSA-v2hh-gcrm-f6hx: fast-uri host confusion via literal backslash
-    # authority delimiter in versions <=3.1.3. Transitive via
-    # @commitlint → ajv (no newer commitlint pin yet).
-    fast-uri: '>=3.1.4'
+    # GHSA-v2hh-gcrm-f6hx (<=3.1.3) and GHSA-7p8r-x3mc-p8w7 (>=4.0.0 <4.1.2):
+    # fast-uri host confusion via literal backslash authority delimiter — the
+    # 3.x fix regressed in the 4.0 rewrite and was re-fixed in 4.1.2. Transitive
+    # via @commitlint → ajv@8 (which still declares `^3.0.1`; the override has
+    # been carrying it on 4.x already, so this only raises the patch floor).
+    fast-uri: '>=4.1.2'
+    # GHSA-5p4m-2wfm-xmqj: quadratic CPU consumption resolving `!!omap`
+    # (CVE-2026-59870), patched at 4.3.1 with no 3.x backport. Transitive via
+    # cosmiconfig@9 (commitlint + semantic-release config loading), which asks
+    # for `^4.1.0`, so the bump stays in-range. Blanket rather than scoped: no
+    # 3.x consumer exists in the tree, and 3.x has no fix to upgrade to, so a
+    # future one should fail loudly here instead of resolving to a vulnerable
+    # version. Capped under 5.0.0: an open floor resolves to js-yaml@5, a major
+    # cosmiconfig does not declare support for.
+    js-yaml: '>=4.3.1 <5.0.0'
     # GHSA-mh99-v99m-4gvg: brace-expansion DoS, patched at 5.0.8. minimatch@10.2.5
     # already calls the modern `{ expand }` API, so bumping here is a safe, direct
     # fix (see auditConfig.ignoreGhsas above for the other, incompatible instance).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,21 +9,6 @@ allowBuilds:
     esbuild: true
     spawn-sync: true
 
-auditConfig:
-    ignoreGhsas:
-        # GHSA-mh99-v99m-4gvg: brace-expansion DoS, patched only at 5.0.8+.
-        # Remaining instance is brace-expansion@1.1.16 via minimatch@3.1.5
-        # (eslint-plugin-react, and multimatch → web-ext-run → wxt). minimatch@3.1.5
-        # calls brace-expansion as `require('brace-expansion')(str)`; 5.0.8 exports
-        # `{ expand }` instead, so forcing the upgrade breaks those callers (verified:
-        # eslint-plugin-react's minimatch-based rules call it the same way). No
-        # minimatch release backports the fix while keeping the old call shape.
-        # devDependency-only: both callers match our own lint/build-time glob
-        # patterns, never attacker-controlled input. The minimatch@10.2.5 instance
-        # (below) is fixed directly. Revisit if eslint-plugin-react or multimatch
-        # ship a minimatch@9+ upgrade.
-        - GHSA-mh99-v99m-4gvg
-
 minimumReleaseAgeExclude:
     - '@eslint/css@1.4.0'
     - '@types/chrome@0.2.1'
@@ -72,10 +57,23 @@ overrides:
     # version. Capped under 5.0.0: an open floor resolves to js-yaml@5, a major
     # cosmiconfig does not declare support for.
     js-yaml: '>=4.3.1 <5.0.0'
-    # GHSA-mh99-v99m-4gvg: brace-expansion DoS, patched at 5.0.8. minimatch@10.2.5
-    # already calls the modern `{ expand }` API, so bumping here is a safe, direct
-    # fix (see auditConfig.ignoreGhsas above for the other, incompatible instance).
-    'minimatch@10.2.5>brace-expansion': '>=5.0.8'
+    # GHSA-mh99-v99m-4gvg (unbounded expansion length OOM) and
+    # GHSA-rgw5-rvv9-x895 (unbounded intermediate arrays, bypassing the
+    # CVE-2026-14257 mitigation): two brace-expansion DoS advisories. The tree
+    # holds exactly two instances, split by which minimatch pulls them, so each
+    # gets a parent-scoped floor that clears both advisories.
+    #
+    # minimatch@10.2.5 already calls the modern `{ expand }` API. Both advisories
+    # are patched on the 5.x line at 5.0.8 and 5.0.9 respectively.
+    'minimatch@10.2.5>brace-expansion': '>=5.0.9'
+    # minimatch@3.1.5 (via eslint-plugin-react, and multimatch → web-ext-run →
+    # wxt) calls brace-expansion as `require('brace-expansion')(str)`, which the
+    # 5.x `{ expand }` export breaks — this instance was previously written off
+    # in auditConfig.ignoreGhsas as unfixable for that reason. It isn't: both
+    # advisories were backported to the 1.x line (1.1.17 and 1.1.18), and 1.1.18
+    # still ships `module.exports = expandTop`, so the old callable shape
+    # survives. Capped under 2.0.0 to keep it on that line.
+    'minimatch@3.1.5>brace-expansion': '>=1.1.18 <2.0.0'
 
 packageExtensions:
     'minimatch@10.2.5':


### PR DESCRIPTION
Closes both open [Dependabot alerts](https://github.com/mrshappy0/mini-mealie/security/dependabot) and clears every remaining `pnpm audit` finding. All are dev-scope transitive dependencies, fixed through the existing `pnpm-workspace.yaml` override mechanism — none has a parent release that pulls in the patched version yet.

**`pnpm audit` is now clean with zero suppressions:** this PR also removes the `auditConfig.ignoreGhsas` entry, which turned out to rest on a false premise (details below).

| Advisory | Severity | Package | Path | Was | Now |
| --- | --- | --- | --- | --- | --- |
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | High | `js-yaml` | `cosmiconfig@9` | 4.3.0 | 4.3.1 |
| [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | High | `fast-uri` | `@commitlint` → `ajv@8` | 4.1.1 | 4.1.2 |
| [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | High | `brace-expansion` | `minimatch@3.1.5` / `@10.2.5` | 1.1.16 / 5.0.8 | 1.1.18 / 5.0.9 |
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | High | `brace-expansion` | `minimatch@3.1.5` | suppressed | fixed |

### js-yaml — quadratic CPU consumption in `!!omap` resolution

CVE-2026-59870, patched at 4.3.1 with no 3.x backport. Reaches the tree via `cosmiconfig@9`, which commitlint and semantic-release use for config loading. cosmiconfig declares `^4.1.0`, so 4.3.1 is in-range.

Added as a blanket override **capped under 5.0.0**. The cap is load-bearing: an open-ended `>=4.3.1` resolves to `js-yaml@5.2.3`, a major cosmiconfig does not declare support for. Blanket rather than scoped because no 3.x consumer exists in the tree and 3.x has no fix to upgrade to — a future one should fail loudly instead of silently resolving to a vulnerable version.

### fast-uri — host confusion via backslash authority introducer

Affects `>=4.0.0 <4.1.2`. This is the 4.x regression of [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) — the 3.x fix was lost in the 4.0 rewrite and re-landed in 4.1.2 — so the existing `fast-uri: '>=3.1.4'` override only needed its floor raised. `ajv@8` still declares `^3.0.1`; the override has been carrying it on 4.x already.

### brace-expansion — two DoS advisories, and why the ignore was wrong

The tree holds exactly two instances, cleanly split by parent:

```
brace-expansion@1.1.16 <- minimatch@3.1.5   (eslint-plugin-react, multimatch -> web-ext-run -> wxt)
brace-expansion@5.0.8  <- minimatch@10.2.5
```

The `auditConfig.ignoreGhsas` entry suppressed GHSA-mh99-v99m-4gvg on the grounds that it was *"patched only at 5.0.8+"*, and that upgrading the 1.x instance was impossible because `minimatch@3.1.5` calls `require('brace-expansion')(str)` while 5.x exports `{ expand }`.

**The call-shape incompatibility is real, but the premise is not.** Both advisories were backported to the 1.x line — GHSA-mh99 at 1.1.17, GHSA-rgw5 at 1.1.18 — and 1.1.18 still ships `module.exports = expandTop`. The old callable shape survives, so the instance is fixable directly and the suppression is unnecessary.

Each instance now gets a parent-scoped floor clearing both advisories: 1.x to `>=1.1.18 <2.0.0` (capped to stay on the callable-export line), 5.x from `>=5.0.8` to `>=5.0.9`.

### Verification

- `pnpm audit` — **no known vulnerabilities, with no ignore entries active**
- `pnpm lint` — clean; exercises `eslint-plugin-react`'s minimatch-based rules
- `pnpm typecheck` — clean
- `pnpm vitest run` — 10 files, 241 tests passing
- `pnpm build` and `pnpm zip` — succeed; `zip` exercises the `web-ext-run`/`multimatch` minimatch@3 path
- `commitlint` and `semantic-release --dry-run` — both load config, exercising `cosmiconfig` → `js-yaml`
- Direct check: `minimatch@3.1.5` resolves to `brace-expansion@1.1.18`, its export is `typeof === "function"`, and `a{b,c}d` globbing matches `abd`/`acd` but not `azd`

### Notes

`postcss` and `nanoid` were on an earlier list of outstanding findings but are already fixed on `main` — #233's wxt 0.21.3 bump carried them to 8.5.26 and 3.3.18, and alerts #39/#37 have since flipped to `fixed`.

Filed as one PR rather than several: all fixes touch the same `overrides` block and `pnpm-lock.yaml`, so split PRs would conflict on whichever merged second. Follows the precedent of #206 (`fix(security)`) and #219/#227 (combined dependency PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
