### PR TITLE
fix(deps): repair AMO uploads and guard the store pipeline against wxt bumps

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -147,14 +147,22 @@ jobs:
               run: |
                   pnpm zip:firefox
 
+            # continue-on-error so a Firefox-side failure doesn't abort the job before
+            # Chrome is even attempted — the two stores fail independently, and the
+            # gate step at the end still fails the run if either one did.
             - name: Submit to Firefox Add-ons
+              id: firefox_submit
               if: steps.firefox.outputs.needed == 'true'
+              continue-on-error: true
               env:
                   FIREFOX_EXTENSION_ID: 'mini-mealie@shaplabs.net'
                   FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
                   VERSION: ${{ steps.target.outputs.VERSION }}
               run: |
                   set -o pipefail
+                  # Fail with a clear message if wxt's artifact naming drifted from the
+                  # globs below, rather than passing an unmatched glob to `wxt submit`.
+                  node scripts/check-store-artifacts.js firefox
                   if pnpm wxt submit \
                         --firefox-zip .output/*-firefox.zip \
                         --firefox-sources-zip .output/*-sources.zip \
@@ -173,7 +181,9 @@ jobs:
                   pnpm zip
 
             - name: Submit to Chrome Store
+              id: chrome_submit
               if: steps.chrome.outputs.needed == 'true'
+              continue-on-error: true
               env:
                   CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
                   CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
@@ -183,6 +193,8 @@ jobs:
                   VERSION: ${{ steps.target.outputs.VERSION }}
               run: |
                   set -o pipefail
+                  # See the Firefox step: catch artifact-naming drift up front.
+                  node scripts/check-store-artifacts.js chrome
                   if pnpm wxt submit \
                         --chrome-zip .output/*-chrome.zip 2>&1 | tee chrome-submit.log; then
                       echo "Chrome: submitted $VERSION for review." >> "$GITHUB_STEP_SUMMARY"
@@ -192,3 +204,22 @@ jobs:
                   else
                       exit 1
                   fi
+
+            # Both submit steps are continue-on-error so neither store can abort the
+            # other, which means the job would otherwise report success even when a
+            # submission failed. Re-fail here on either outcome.
+            - name: Fail if any store submission failed
+              if: steps.firefox_submit.outcome == 'failure' || steps.chrome_submit.outcome == 'failure'
+              env:
+                  FIREFOX_OUTCOME: ${{ steps.firefox_submit.outcome }}
+                  CHROME_OUTCOME: ${{ steps.chrome_submit.outcome }}
+              run: |
+                  if [[ "$FIREFOX_OUTCOME" == "failure" ]]; then
+                      echo "::error::Firefox Add-ons submission failed — see the 'Submit to Firefox Add-ons' step."
+                      echo "Firefox: submission FAILED." >> "$GITHUB_STEP_SUMMARY"
+                  fi
+                  if [[ "$CHROME_OUTCOME" == "failure" ]]; then
+                      echo "::error::Chrome Web Store submission failed — see the 'Submit to Chrome Store' step."
+                      echo "Chrome: submission FAILED." >> "$GITHUB_STEP_SUMMARY"
+                  fi
+                  exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,31 @@ jobs:
               run: |
                   chmod +x scripts/check-coverage.sh
                   scripts/check-coverage.sh
+
+    # submit.yml only runs on release/schedule, so nothing else exercises the store
+    # packaging path on a PR. A wxt bump that renames or drops a zip artifact would
+    # otherwise stay invisible until a release failed mid-submission. Build the real
+    # store artifacts here and assert they still match the globs submit.yml passes.
+    store-artifacts:
+        name: Store Artifact Contract
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v7
+
+            - name: Setup
+              uses: ./.github/actions/setup
+
+            # package.json is versionless (private package); submit.yml injects the
+            # release version before zipping, so mirror that to get realistic filenames.
+            - name: Inject a placeholder version
+              run: npm pkg set version=0.0.0-ci
+
+            - name: Build store zips
+              run: |
+                  pnpm zip:firefox
+                  pnpm zip
+
+            - name: Verify artifacts match submit.yml globs
+              run: node scripts/check-store-artifacts.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3173,8 +3173,8 @@ packages:
       kerberos:
         optional: true
 
-  publish-browser-extension@6.0.0:
-    resolution: {integrity: sha512-DStg6sPhxBBECBQmx2hAT3MJY0BIdkx1JCiL3laowL/QHi4Wi2mE3BXCGMXFgU63b2T9JVR+9uD8XPASfZIQhA==}
+  publish-browser-extension@6.1.1:
+    resolution: {integrity: sha512-ovfBOz+cZIOBHZ+oxTfpv1kSGU7ruzy8CXoFGvhXsUbJuty45srGzf1ufEePs69virOWXfFbhZRoNQUdgPvwXA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -7060,7 +7060,7 @@ snapshots:
 
   proxy-agent-negotiate@1.1.0: {}
 
-  publish-browser-extension@6.0.0:
+  publish-browser-extension@6.1.1:
     dependencies:
       '@topcli/prompts': 4.0.0
       cac: 7.0.0
@@ -7963,7 +7963,7 @@ snapshots:
       nypm: 0.6.8
       ohash: 2.0.11
       picomatch: 4.0.5
-      publish-browser-extension: 6.0.0
+      publish-browser-extension: 6.1.1
       scule: 1.3.0
       superlock: 1.3.5
       tiny-open: 1.3.0

--- a/scripts/check-store-artifacts.js
+++ b/scripts/check-store-artifacts.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Verify that `wxt zip` produced exactly the artifacts submit.yml will hand to
+ * the stores.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * submit.yml passes shell globs to `wxt submit`:
+ *
+ *     --firefox-zip         .output/*-firefox.zip
+ *     --firefox-sources-zip .output/*-sources.zip
+ *     --chrome-zip          .output/*-chrome.zip
+ *
+ * Those globs encode an assumption about wxt's artifact naming
+ * (`{{name}}-{{packageVersion}}-{{browser}}{{modeSuffix}}.zip` and
+ * `{{name}}-{{packageVersion}}-sources{{modeSuffix}}.zip`). If a wxt bump
+ * renames or stops emitting an artifact, an unmatched glob is passed through
+ * literally by bash and the failure surfaces as a confusing store-side error
+ * during a release — or, worse, a submission missing its sources zip.
+ *
+ * The patterns are parsed out of submit.yml rather than duplicated here, so the
+ * workflow stays the single source of truth and this check cannot silently
+ * drift from what actually ships.
+ *
+ * Usage:  node scripts/check-store-artifacts.js [firefox|chrome]
+ *         (no argument checks every store)
+ */
+import { glob, readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+const WORKFLOW = '.github/workflows/submit.yml';
+
+/**
+ * Which `--*-zip` flags in submit.yml belong to which store. A Map rather than a
+ * plain object so lookups by CLI argument aren't a dynamic property read.
+ */
+const STORE_FLAGS = new Map([
+    ['firefox', ['firefox-zip', 'firefox-sources-zip']],
+    ['chrome', ['chrome-zip']],
+]);
+
+/**
+ * Pull the glob a given `--<flag>` is invoked with out of the workflow, so the
+ * check always reflects what submit.yml actually passes. Scans lines rather than
+ * building a regex from the flag name, which keeps the match anchored to a real
+ * `--flag value` pair (`--firefox-zip ` cannot match `--firefox-sources-zip`).
+ */
+function extractPattern(workflow, flag) {
+    const line = workflow.split('\n').find((l) => l.includes(`--${flag} `));
+    const pattern = line?.trim().split(/\s+/)[1];
+    if (!pattern) {
+        throw new Error(
+            `Could not find \`--${flag}\` in ${WORKFLOW}. If the flag was renamed or ` +
+                `removed, update STORE_FLAGS in this script to match.`,
+        );
+    }
+    return pattern;
+}
+
+async function main() {
+    const requested = process.argv[2];
+    if (requested && !STORE_FLAGS.has(requested)) {
+        console.error(
+            `Unknown store "${requested}". Expected one of: ${[...STORE_FLAGS.keys()].join(', ')}`,
+        );
+        process.exit(2);
+    }
+
+    const workflow = await readFile(WORKFLOW, 'utf8');
+    const stores = requested ? [requested] : [...STORE_FLAGS.keys()];
+    const failures = [];
+
+    for (const store of stores) {
+        for (const flag of STORE_FLAGS.get(store)) {
+            const pattern = extractPattern(workflow, flag);
+            const matches = [];
+            for await (const entry of glob(pattern)) matches.push(entry);
+
+            if (matches.length === 1) {
+                console.log(`ok    --${flag}  ${pattern}  ->  ${matches[0]}`);
+            } else if (matches.length === 0) {
+                failures.push(
+                    `--${flag}: pattern "${pattern}" matched no files. wxt likely renamed or ` +
+                        `stopped emitting this artifact.`,
+                );
+            } else {
+                failures.push(
+                    `--${flag}: pattern "${pattern}" matched ${matches.length} files ` +
+                        `(${matches.join(', ')}). The submit step needs exactly one.`,
+                );
+            }
+        }
+    }
+
+    if (failures.length > 0) {
+        console.error('\nStore artifact contract violated:\n');
+        for (const failure of failures) console.error(`  - ${failure}`);
+        console.error(
+            `\nsubmit.yml would pass an unmatched glob straight through to \`wxt submit\`, ` +
+                `failing the release. Fix wxt's zip config or update the globs in ${WORKFLOW}.\n`,
+        );
+        process.exit(1);
+    }
+
+    console.log(`\nAll store artifacts match the globs in ${WORKFLOW}.`);
+}
+
+await main();

--- a/scripts/tests/store-submit-contract.test.ts
+++ b/scripts/tests/store-submit-contract.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment node
+/**
+ * Contract test for the AMO (Firefox Add-ons) submission wire format.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The v1.5.17 store submission failed with a 400 from AMO:
+ *
+ *     "source": ["Unsupported file type, please upload an archive file
+ *                 (.zip, .tar.gz, .tgz, .tar.bz2)."]
+ *
+ * Nothing in this repo changed. A wxt bump (0.20.27 -> 0.21.3) carried
+ * publish-browser-extension 4.0.5 -> 6.0.0, and across that jump the sources
+ * attachment changed from a named file to a nameless blob:
+ *
+ *     v4.0.5   form.set("source", await fileFromPath(path))       // filename="x-sources.zip"
+ *     v6.0.0   versionBody.set("source", await openAsBlob(path))  // filename="blob"  <-- rejected
+ *     v6.1.1   versionBody.set("source", await openAsFile(path))  // filename="x-sources.zip"
+ *
+ * `fs.openAsBlob()` returns a Blob with no name. Per the FormData spec a bare
+ * Blob is wrapped into a File literally named "blob", so the part serializes as
+ * `filename="blob"`. AMO validates that attachment by file extension, finds no
+ * `.zip`, and rejects the whole submission.
+ *
+ * Note the consequence for assertions below: an `instanceof File` check does
+ * NOT catch this, because the broken version also produces a File. Only the
+ * filename distinguishes them.
+ *
+ * That failure mode is invisible until a real release hits AMO, which is far
+ * too late. This test drives the real `FirefoxAddonStoreV5.submit()` against a
+ * stubbed `fetch` and asserts the multipart parts carry `.zip` filenames, so a
+ * future wxt bump that regresses the serialization fails here on the PR
+ * instead of on the release.
+ *
+ * The store class is resolved through wxt's own module graph rather than a
+ * direct import, so this exercises the exact publish-browser-extension
+ * instance `pnpm wxt submit` will use — including whatever version a future
+ * wxt bump resolves to.
+ */
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+/** Minimal but structurally valid empty-ZIP bytes (end-of-central-directory record only). */
+const EMPTY_ZIP = Buffer.from([
+    0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+
+const EXTENSION_ID = 'mini-mealie@shaplabs.net';
+
+/**
+ * Structural type for the slice of publish-browser-extension used here.
+ *
+ * Declared locally rather than imported: the package is wxt's transitive
+ * dependency, not ours, so it isn't resolvable by name from this project. Adding
+ * it as a direct devDependency would make the types resolve but would also
+ * risk pinning a *different* copy than the one wxt loads at submit time, which
+ * is precisely what this test exists to check.
+ */
+interface FirefoxStoreModule {
+    FirefoxAddonStoreV5: new (
+        options: {
+            zip: string;
+            sourcesZip?: string;
+            extensionId: string;
+            channel: 'listed' | 'unlisted';
+            jwtIssuer: string;
+            jwtSecret: string;
+            skipSubmitReview: boolean;
+        },
+        setStatus: (text: string) => void,
+    ) => { submit(dryRun?: boolean): Promise<void> };
+}
+
+/** Resolve publish-browser-extension the way `wxt submit` does, not as a direct dependency. */
+async function importStoreAsWxtSeesIt(): Promise<FirefoxStoreModule> {
+    const require = createRequire(import.meta.url);
+    const wxtEntry = require.resolve('wxt');
+    const storeEntry = createRequire(wxtEntry).resolve('publish-browser-extension');
+    return (await import(storeEntry)) as FirefoxStoreModule;
+}
+
+/** A single captured outbound request. */
+interface CapturedRequest {
+    method: string;
+    url: string;
+    body: unknown;
+}
+
+/**
+ * Stand-in for the AMO v5 API. Returns the minimum shape `submit()` reads at
+ * each step, and records every request so the test can inspect what was sent.
+ */
+function stubAmoApi(captured: CapturedRequest[]) {
+    return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? 'GET';
+        captured.push({ method, url, body: init?.body });
+
+        const json = (data: unknown) =>
+            new Response(JSON.stringify(data), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+        // Order matters: the upload-status route is a longer match than the
+        // upload-create route, so it has to be tested first.
+        if (url.includes('/api/v5/addons/upload/') && method === 'GET') {
+            return json({ uuid: 'test-upload-uuid', processed: true, valid: true, validation: {} });
+        }
+        if (url.includes('/api/v5/addons/upload/') && method === 'POST') {
+            return json({ uuid: 'test-upload-uuid' });
+        }
+        if (url.includes('/versions/') && method === 'POST') {
+            return json({ id: 456, file: { id: 789 } });
+        }
+        if (url.includes('/api/v5/addons/addon/')) {
+            return json({ id: 123, slug: 'mini-mealie' });
+        }
+        throw new Error(`Unstubbed AMO request: ${method} ${url}`);
+    });
+}
+
+describe('AMO submission wire format', () => {
+    let dir: string;
+    let zip: string;
+    let sourcesZip: string;
+    let captured: CapturedRequest[];
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeAll(async () => {
+        dir = await mkdtemp(join(tmpdir(), 'mini-mealie-submit-'));
+        zip = join(dir, 'mini-mealie-9.9.9-firefox.zip');
+        sourcesZip = join(dir, 'mini-mealie-9.9.9-sources.zip');
+        // Paths are freshly-created temp dirs, not attacker-influenced input.
+        /* eslint-disable security/detect-non-literal-fs-filename */
+        await writeFile(zip, EMPTY_ZIP);
+        await writeFile(sourcesZip, EMPTY_ZIP);
+        /* eslint-enable security/detect-non-literal-fs-filename */
+
+        const { FirefoxAddonStoreV5 } = await importStoreAsWxtSeesIt();
+
+        captured = [];
+        originalFetch = globalThis.fetch;
+        globalThis.fetch = stubAmoApi(captured) as unknown as typeof globalThis.fetch;
+
+        try {
+            // Mirrors the flags submit.yml passes: listed channel, sources zip
+            // attached, no AMO metadata file.
+            const store = new FirefoxAddonStoreV5(
+                {
+                    zip,
+                    sourcesZip,
+                    extensionId: EXTENSION_ID,
+                    channel: 'listed',
+                    jwtIssuer: 'test-issuer',
+                    jwtSecret: 'test-secret',
+                    skipSubmitReview: false,
+                },
+                () => {},
+            );
+            await store.submit();
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    afterAll(async () => {
+        await rm(dir, { recursive: true, force: true });
+    });
+
+    /** The FormData sent to the version-create endpoint, which carries the sources zip. */
+    const versionRequest = () => {
+        const req = captured.find((r) => r.url.includes('/versions/') && r.method === 'POST');
+        expect(req, 'expected a POST to the AMO versions endpoint').toBeDefined();
+        expect(req!.body).toBeInstanceOf(FormData);
+        return req!.body as FormData;
+    };
+
+    it('attaches the sources zip as a named file, not a bare blob', () => {
+        const source = versionRequest().get('source');
+
+        // Sanity check only — this passes on the broken version too, since
+        // FormData wraps a nameless Blob into a File called "blob".
+        expect(source).toBeInstanceOf(File);
+
+        // This is the assertion that actually catches the regression: verified
+        // against publish-browser-extension@6.0.0, where the name is "blob".
+        expect((source as File).name).toBe('mini-mealie-9.9.9-sources.zip');
+    });
+
+    it('serializes the sources part with a .zip filename on the wire', async () => {
+        // Assert against the encoded multipart body rather than just the object,
+        // since the filename AMO validates comes from serialization.
+        const body = await new Response(versionRequest()).text();
+        const disposition = body.match(/name="source"[^\r\n]*/)?.[0] ?? '';
+
+        expect(disposition).toContain('filename="mini-mealie-9.9.9-sources.zip"');
+        expect(disposition).not.toContain('filename="blob"');
+    });
+
+    it('attaches the extension zip as a named file', async () => {
+        const upload = captured.find(
+            (r) => r.url.includes('/api/v5/addons/upload/') && r.method === 'POST',
+        );
+        expect(upload, 'expected a POST to the AMO upload endpoint').toBeDefined();
+        expect(upload!.body).toBeInstanceOf(FormData);
+
+        const file = (upload!.body as FormData).get('upload');
+        expect(file).toBeInstanceOf(File);
+        expect((file as File).name).toBe('mini-mealie-9.9.9-firefox.zip');
+    });
+});


### PR DESCRIPTION
Repairs the Firefox Add-ons submission, which failed on the [v1.5.17 release run](https://github.com/mrshappy0/mini-mealie/actions/runs/31519090378/job/93871434139), and adds guards so this class of failure surfaces on a PR instead of mid-release.

```
"source": ["Unsupported file type, please upload an archive file (.zip, .tar.gz, .tgz, .tar.bz2)."]
```

The extension ZIP uploaded and validated fine — it was the **sources ZIP** that AMO rejected.

## Root cause: upstream, not our workflow or our zips

#233 bumped wxt 0.20.27 → 0.21.3, which carried `publish-browser-extension` **4.0.5 → 6.0.0**. Across that jump the source attachment changed from a named file to a nameless blob:

```js
// v4.0.5 — named File, part carries filename="…-sources.zip"
form.set("source", await fileFromPath(params.sourceFile));

// v6.0.0 — nameless Blob, part carries filename="blob"
versionBody.set("source", await openAsBlob(this.options.sourcesZip));
```

Per the FormData spec a bare Blob is wrapped into a File literally named `"blob"`. AMO validates the source attachment by extension, finds no `.zip`, and 400s. The extension ZIP survived because `/api/v5/addons/upload/` doesn't apply that check.

Verified directly against a real sources zip:

```
v6.0.0 (openAsBlob):  name="source"; filename="blob"
v6.1.1 (openAsFile):  name="source"; filename="mini-mealie-1.5.17-sources.zip"
```

Upstream fixed it in 6.1.0 by wrapping the blob in a named `File`. `wxt@0.21.3` declares `^5.1.0 || ^6.0.0`, so 6.1.1 satisfies the existing range — **the fix itself is a 4-line lockfile refresh**, no override needed.

## Guards added

Nothing in this repo changed to cause the outage; a transitive dependency's wire format did. Three guards so the next one fails early.

**1. AMO submission contract test** — `scripts/tests/store-submit-contract.test.ts`

Drives the real `FirefoxAddonStoreV5.submit()` against a stubbed `fetch` and asserts the multipart parts carry `.zip` filenames. Confirmed to fail against `publish-browser-extension@6.0.0`.

Two deliberate choices worth flagging for review:

- `instanceof File` does **not** catch this — FormData wraps a nameless Blob into a File named `"blob"`, so the broken version passes that check. Only the filename discriminates, so the test asserts both the `File.name` and the encoded multipart body.
- The store class is resolved through **wxt's own module graph** rather than imported by name, so the test exercises whichever copy `pnpm wxt submit` actually loads, including after a future wxt bump. That's also why its types are declared structurally instead of adding a direct devDependency — a direct dep would resolve for TypeScript but could pin a *different* copy than wxt loads, defeating the purpose.

Chrome isn't covered: it uploads via `createReadStream`, not FormData, so this failure mode doesn't apply.

**2. Store artifact contract** — `scripts/check-store-artifacts.js`

submit.yml passes shell globs (`.output/*-sources.zip`, etc.) that encode an assumption about wxt's artifact naming. An unmatched glob is passed through literally by bash and surfaces as a confusing store-side error — or a submission silently missing its sources zip.

The script parses the patterns **out of submit.yml** rather than duplicating them, so the workflow stays the single source of truth, and asserts each matches exactly one file. It runs in both submit steps (fail fast, clear message) and in a new **Store Artifact Contract** PR job, since submit.yml itself only runs on release/schedule.

**3. Stores no longer take each other down** — `submit.yml`

Chrome's steps sat after Firefox's, so the AMO failure aborted the job and **v1.5.17 reached neither store**. Both submit steps are now `continue-on-error` with a gate step that re-fails the run on either outcome: independent failures, same overall result.

## v1.5.17 will not self-heal — it rolls forward

`submit.yml` does `git checkout refs/tags/<TAG>` *before* `Setup`, so each submission installs from the **release tag's** lockfile rather than `main`. The v1.5.17 tag pins 6.0.0, so the 4-hourly catch-up cron will keep failing against it until a newer release exists.

Merging cuts **v1.5.18**, whose tag carries 6.1.1; that run submits successfully and v1.5.17 collapses into it — the stacking behaviour the cron is documented to handle. Expect up to one more red catch-up run against v1.5.17 in the meantime.

## Verification

- `pnpm vitest run` — 244 tests across 11 files (3 new)
- `pnpm typecheck`, `pnpm lint` — clean, **no new warnings** (repo baseline is 0)
- Coverage gate — unaffected at 92.91%; the new test lives outside `utils/**`
- Both workflows parse; `continue-on-error` / gate wiring confirmed
- Artifact guard exercised against **missing**, **ambiguous**, and **unknown-store** cases
- Contract test confirmed to fail on 6.0.0 and pass on 6.1.1

## Note for reviewers

`check-store-artifacts` is `.js`, not `.mjs`, because `eslint.config.js` applies `react/*` rules to `**/*.{js,mjs,cjs,ts,jsx,tsx}` while registering the react plugin only for `**/*.{js,ts,jsx,tsx}`. A `.mjs` file is the one extension that receives the rules without the plugin, and ESLint hard-errors on it. `.js` also matches the existing `scripts/` convention. **The latent config gap is still there** for any future `.mjs` file — left alone as out of scope, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
