### PR TITLE
fix(build): disable Vite modulepreload so extension pages stop refetching the React chunk

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -35,6 +35,18 @@ export default defineConfig({
         define: {
             'import.meta.env.WXT_E2E': JSON.stringify(process.env.WXT_E2E === 'true'),
         },
+        build: {
+            /**
+             * Drop the `<link rel="modulepreload">` Vite injects into popup.html/logs.html for
+             * the shared `chunks/jsx-runtime-*.js` chunk. On a `chrome-extension://` page Chrome
+             * will not match a parser-initiated preload against the module loader's own fetch —
+             * it logs "cross-world extension resource mismatch" plus "preloaded ... but not used
+             * within a few seconds" and then fetches the chunk a second time. The preload buys
+             * nothing here anyway: the chunk is a static import of the entry, so it is discovered
+             * one parse later and read off local disk, not the network.
+             */
+            modulePreload: false,
+        },
     }),
     manifest: ({ browser }) => ({
         permissions: ['storage', 'activeTab', 'contextMenus', 'scripting'],


### PR DESCRIPTION
## What

One line in `wxt.config.ts`: `build.modulePreload: false`.

This removes the `<link rel="modulepreload">` Vite injects into `popup.html` and `logs.html`, and with it the two console warnings that have shipped in every build of this extension for years:

```
A preload for 'chrome-extension://<id>/chunks/jsx-runtime-Ccx_2vg8.js' is found,
but is not used because it is a cross-world extension resource mismatch.

The resource chrome-extension://<id>/chunks/jsx-runtime-Ccx_2vg8.js was preloaded
using link preload but not used within a few seconds from the window's load event.
```

## Why

Not a WXT bug and not an application bug — a web optimization that misfires on extension pages.

Both HTML entrypoints use React, so Rollup hoists React + `jsx-runtime` into a shared 193 kB chunk and Vite adds a `modulepreload` link for it to each page. On a `chrome-extension://` page the preload is issued by the HTML parser's preload scanner, while the actual fetch is issued later by the module loader on behalf of the page's script world. Chrome will not match the two: it logs the cross-world mismatch, **refetches the chunk**, and three seconds later trips the "preloaded but not used" warning on the now-orphaned preload.

The two errors are the same event — the first says the preload was rejected, the second says nobody claimed it. So the preload was never buying anything; it was costing a duplicate fetch. Disabling it means the chunk loads as a static import of the entry, one parse tick later, off local disk rather than the network.

## Verification

Built the extension both ways, loaded each in Chromium via Playwright with `--load-extension`, and captured browser-level console output over CDP (`Log.entryAdded` — these are browser-emitted, so a plain `page.on('console')` listener alone is not sufficient to catch them):

| | before | after |
|---|---|---|
| preload warnings | 8 | **0** |
| console entries, all types | 8 | **none** |
| `popup.html` `#root` rendered | 1187 chars | 1187 chars |
| `logs.html` `#root` rendered | 711 chars | 711 chars |

The before-run reproduced the reported messages verbatim, down to the same chunk hash `jsx-runtime-Ccx_2vg8.js`.

Also green: `pnpm test` (92.91% statements), `pnpm typecheck`, `pnpm lint`, and the Firefox MV2 build — whose `popup.html` comes out equally clean.

## Reviewer notes

- **`logs.html` was affected too.** It was throwing the identical pair of warnings; only the popup was ever reported. Both are fixed, since the setting is build-wide.
- **Output chunk hashes change** (`jsx-runtime-Ccx_2vg8` → `jsx-runtime--ZuPEOMs`, etc.). Expected — the emitted HTML changed. Total bundle size is unchanged at ~306 kB.
- **The E2E suites were not run** (`test:e2e:chromium`, `test:e2e:gecko`), as they need the Dockerized Mealie instance. The render assertions in the table cover what those would catch for a change at this layer, but happy to run them if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)