### PR TITLE
test(background): stop leaked webNavigation listeners flaking the suite

### DIFF
--- a/entrypoints/tests/background.test.ts
+++ b/entrypoints/tests/background.test.ts
@@ -216,6 +216,21 @@ describe('background', () => {
             await new Promise((resolve) => setTimeout(resolve, 300));
             expect(checkStorageAndUpdateBadge).not.toHaveBeenCalled();
         });
+
+        // Guard for a real flake: fakeBrowser.reset() doesn't reset webNavigation (it has no
+        // resetState()), so every beforeEach's main() used to stack another live onCommitted
+        // listener. Each duplicate scheduled its own debounced refresh, and the ones that
+        // hadn't fired when a test ended landed in the next test, making the "does not
+        // refresh" assertions above fail at random. vitest.setup.ts clears them; this asserts
+        // it still works. Deliberately last in this block, and on a restricted URL so the
+        // handler returns early instead of leaving a timer behind.
+        it('registers exactly one navigation listener per test', async () => {
+            const results = await fakeBrowser.webNavigation.onCommitted.trigger(
+                makeCommitDetails({ url: 'chrome://extensions' }),
+            );
+
+            expect(results).toHaveLength(1);
+        });
     });
 
     describe('contextMenus.onClicked dispatch', () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
 
 // `test.globals` isn't enabled, so @testing-library/react can't auto-detect a
 // global `afterEach` to clean up between tests. Without this, every render()
@@ -67,6 +68,28 @@ function withCallbackSupport(area: unknown) {
         });
     }
 }
+
+/**
+ * `fakeBrowser.reset()` only resets namespaces that implement `resetState()`, and
+ * `webNavigation` is the one namespace that doesn't (see @webext-core/fake-browser) — it is
+ * events-only, so its listeners survive every reset.
+ *
+ * That silently breaks any suite that re-runs a background entrypoint per test: each
+ * `main()` adds another live `webNavigation.onCommitted` listener on top of the previous
+ * test's, so a single navigation trigger runs N copies of the handler, each scheduling its
+ * own debounced badge refresh from its own closure. `vi.waitFor` returns after the first one
+ * fires and the rest land in the *next* test — after `vi.clearAllMocks()` — where a
+ * "should not refresh" assertion then sees phantom calls. Clear them explicitly.
+ */
+beforeEach(() => {
+    const webNavigation = fakeBrowser.webNavigation as unknown as Record<
+        string,
+        { removeAllListeners?: () => void } | undefined
+    >;
+    for (const event of Object.values(webNavigation)) {
+        event?.removeAllListeners?.();
+    }
+});
 
 beforeEach(() => {
     if (typeof chrome === 'undefined') return;


### PR DESCRIPTION
Fixes the `Upload Code Coverage` failure on `main` ([run 34039204198](https://github.com/mrshappy0/mini-mealie/actions/runs/34039204198/job/101502752115)):

```
FAIL entrypoints/tests/background.test.ts > background > badge/menu refresh triggers
  > does not refresh when a tab navigates to a restricted URL
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 3 times
```

## It wasn't the dependabot bump

`@html-eslint/parser` is lint-only and never loads in the test path. The merge just lost a coin flip on a flaky test that has been latent since the `webNavigation` tests were added — the identical code passed on #262 (`Run Tests`, 36s) and failed on `main`.

## Root cause

`fakeBrowser.reset()` only resets namespaces that implement `resetState()`, and `webNavigation` is the one namespace in `@webext-core/fake-browser` that doesn't — it's events-only, so its listeners survive every reset.

`background.test.ts` calls `backgroundDef.main()` in `beforeEach`, so every test stacked another live `onCommitted` listener on top of all the previous ones. Measured: 14 listeners registered by the end of the file where there should be 1.

One navigation trigger then ran N copies of the handler, each scheduling its own 250ms debounced `checkStorageAndUpdateBadge()` from its own closure. `vi.waitFor` returns after the *first* fires and the test ends — the rest fire during the next test, after `vi.clearAllMocks()`. That is exactly the observed failure: the 4th test (`refreshes when a tab commits a real navigation`) had 4 stacked listeners, 1 satisfied the wait, and the other **3** landed on the next test's `expect(...).not.toHaveBeenCalled()`.

This is a test-harness artifact only. Real Chrome registers the background listeners once; nothing is wrong with the extension itself.

## Changes

- **`vitest.setup.ts`** — clear `webNavigation`'s listeners in a global `beforeEach`, since `fakeBrowser.reset()` won't. It runs before the file-level `beforeEach`, so each test gets exactly one background instance.
- **`entrypoints/tests/background.test.ts`** — a guard asserting exactly one navigation listener is registered, placed last in that block where a leak is guaranteed to show. Verified it fails (14, not 1) with the setup fix disabled, so a regression fails deterministically instead of once every N runs.

## Verification

- Full suite green 3x with `--coverage`; coverage unchanged at 93.39%, matching CI.
- `tsc --noEmit` and `eslint` clean.

Committed as `test(...)` so semantic-release won't cut a release for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
