### PR TITLE
fix(security): patch fast-uri advisories, document unpatched adm-zip

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   firefox-profile>adm-zip: '>=0.6.0'
   '@actions/http-client>undici': '>=7.28.0'
   jsdom>undici: '>=7.28.0 <8.0.0'
-  fast-uri: '>=4.1.2'
+  fast-uri: '>=4.1.3'
   js-yaml: '>=4.3.1 <5.0.0'
   minimatch@10.2.5>brace-expansion: '>=5.0.9'
   minimatch@3.1.5>brace-expansion: '>=1.1.18 <2.0.0'
@@ -682,10 +682,6 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/plugin-kit@0.7.2':
-    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/plugin-kit@0.7.3':
     resolution: {integrity: sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==}
@@ -2333,8 +2329,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -5226,11 +5222,6 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@eslint/plugin-kit@0.7.2':
-    dependencies:
-      '@eslint/core': 1.2.1
-      levn: 0.4.1
-
   '@eslint/plugin-kit@0.7.3':
     dependencies:
       '@eslint/core': 1.2.1
@@ -6000,7 +5991,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7067,7 +7058,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.4: {}
 
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,13 @@ overrides:
     esbuild: '>=0.28.1'
     # GHSA-xcpc-8h2w-3j85: adm-zip crafted ZIP triggers 4GB memory allocation.
     # web-ext-run@0.2.4 (no newer release) pins firefox-profile which pins adm-zip@0.5.18.
+    #
+    # GHSA-vwc7-r8mq-g2x9 (CVE-2026-76845, symlink-following on extraction) covers
+    # 0.5.9–0.6.0 and has NO patched release yet (upstream cthackers/adm-zip#575
+    # still open). Not exploitable here: firefox-profile's only extraction is
+    # `extractAllTo(tmpDir, true)` into a fresh fs.mkdtempSync() directory, so no
+    # pre-existing attacker symlink can sit at the destination. Dev-only (web-ext).
+    # Raise this floor once a fixed adm-zip ships.
     firefox-profile>adm-zip: '>=0.6.0'
     # CVE-2026-6734, CVE-2026-9697 (HIGH), CVE-2026-9679, CVE-2026-9678
     # (MEDIUM), CVE-2026-11525, CVE-2026-6733 (LOW): undici vulnerabilities
@@ -47,7 +54,11 @@ overrides:
     # 3.x fix regressed in the 4.0 rewrite and was re-fixed in 4.1.2. Transitive
     # via @commitlint → ajv@8 (which still declares `^3.0.1`; the override has
     # been carrying it on 4.x already, so this only raises the patch floor).
-    fast-uri: '>=4.1.2'
+    # Floor raised to 4.1.3 for GHSA-jqff-g426-hqxp (percent-encoded scheme
+    # normalization), GHSA-fph4-wmhf-6fwf (repeated hostname percent-decoding
+    # SSRF), GHSA-f65p-4m7j-42xc (malformed IPv6 normalization SSRF), and
+    # GHSA-5jgf-p345-68v8 (skipped IDN canonicalization on scheme-relative refs).
+    fast-uri: '>=4.1.3'
     # GHSA-5p4m-2wfm-xmqj: quadratic CPU consumption resolving `!!omap`
     # (CVE-2026-59870), patched at 4.3.1 with no 3.x backport. Transitive via
     # cosmiconfig@9 (commitlint + semantic-release config loading), which asks


### PR DESCRIPTION
Addresses the 5 open Dependabot alerts.

## Fixed — fast-uri (4 × high)

| Alert | Advisory | Issue |
|---|---|---|
| #42 | GHSA-jqff-g426-hqxp | Host confusion via percent-encoded scheme normalization |
| #43 | GHSA-fph4-wmhf-6fwf | SSRF via repeated hostname percent-decoding |
| #44 | GHSA-f65p-4m7j-42xc | SSRF via malformed IPv6 normalization |
| #45 | GHSA-5jgf-p345-68v8 | Host confusion via skipped IDN canonicalization |

Raised the existing `fast-uri` override floor `>=4.1.2` → `>=4.1.3`; lockfile now resolves **4.1.4**. Path is `@commitlint` → `ajv@8` → `fast-uri` (dev-only). pnpm also pruned an orphaned `@eslint/plugin-kit@0.7.2` entry.

## Not fixable yet — adm-zip (#48, medium)

GHSA-vwc7-r8mq-g2x9 / CVE-2026-76845 (symlink-following on extraction) affects `0.5.9`–`0.6.0`, and **0.6.0 is the latest release** — there is no patched version (upstream fix cthackers/adm-zip#575 is still open).

Assessed as not exploitable in this repo:
- Only consumer is `web-ext` → `firefox-profile@4.7.1` (devDependency, never shipped).
- firefox-profile's only extraction is `zip.extractAllTo(tmpDir, true)` where `tmpDir` comes from `fs.mkdtempSync()` — a freshly created, randomly named directory, so no attacker-planted symlink can pre-exist at the destination.

Documented this in `pnpm-workspace.yaml` next to the existing adm-zip override, with a note to raise the floor once a fix ships. The alert will stay open until then (or can be dismissed as tolerable risk).

## Verification
- `pnpm lint` ✅ · `pnpm typecheck` ✅ · `commitlint` smoke test (exercises ajv/fast-uri) ✅
- `vitest`: 266/266 tests pass. `App.test.tsx` fails to *load* on Windows only (`file:///mini-mealie.svg` path error) — pre-existing and unrelated; CI runs on Ubuntu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
