### PR TITLE
fix(release): stop pre-push hook from blocking semantic-release

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,15 +15,26 @@
 #
 # Only commits that exist on no remote-tracking branch are checked, so history merged
 # in from main is never re-litigated. Set ALLOW_UNSIGNED_PUSH=1 to bypass.
+#
+# Only branch pushes are checked. Tags and notes refs are written by tooling (e.g.
+# semantic-release's `git notes add` for refs/notes/semantic-release-*), which can't
+# sign. The hook is also skipped in CI (postinstall installs it there too), where no
+# signing key exists and nothing pushed is a hand-written commit.
 
 [ "$ALLOW_UNSIGNED_PUSH" = "1" ] && exit 0
+[ "$CI" = "true" ] && exit 0
 
 status=0
 
-while read -r _local_ref local_sha _remote_ref _remote_sha; do
+while read -r _local_ref local_sha remote_ref _remote_sha; do
     # All-zero sha means the ref is being deleted; nothing to check.
     case "$local_sha" in
         *[!0]*) ;;
+        *) continue ;;
+    esac
+
+    case "$remote_ref" in
+        refs/heads/*) ;;
         *) continue ;;
     esac
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Windows note: if PowerShell blocks `pnpm.ps1`, prefer `pnpm.cmd` or adjust execu
     - Local helper: `pnpm commitlint` validates a message; the `.githooks/commit-msg` hook runs commitlint automatically on every commit.
     - CI enforces this on all PRs via `.github/workflows/commitlint.yml` — PRs with non-conventional commits cannot merge.
     - Keep commit message body lines ≤ 100 characters. Agent-generated commits (those containing `Agent-Logs-Url:`) are automatically skipped by commitlint, so long trailers in agent commit bodies won't fail CI.
-- **Every commit must be signed.** `commit.gpgsign` is enabled globally and `.githooks/pre-push` refuses to push any commit that carries no signature.
+- **Every commit must be signed.** `commit.gpgsign` is enabled globally and `.githooks/pre-push` refuses to push any commit that carries no signature. It only checks branch pushes and is skipped in CI, so semantic-release's tag and notes pushes aren't blocked.
     - Never reach for `--no-gpg-sign`, `-c commit.gpgsign=false`, or `--no-verify` to get past a signing or hook failure. If signing breaks, stop and report it — a bypassed commit lands on the PR as **Unverified** and nobody notices until review.
     - To re-sign a branch that already has unsigned commits: `git rebase -S origin/main && git push --force-with-lease`.
 - Releases are driven by commit history and semantic versioning via **semantic-release**.


### PR DESCRIPTION
## Why

[Release run 34546649861](https://github.com/mrshappy0/mini-mealie/actions/runs/34546649861) failed. `postinstall` sets `core.hooksPath .githooks` in CI too, so the unsigned-commit pre-push hook from #275 ran when semantic-release pushed `refs/notes/semantic-release-v1.6.1`. The notes commit made by `git notes add` is unsigned, so the hook rejected it.

The `v1.6.1` tag had already been pushed by then, but the GitHub release was never created, so `submit.yml` and `release-email.yml` never ran.

## Changes

- `.githooks/pre-push` now checks only `refs/heads/*` pushes and exits early when `CI=true`. Local unsigned branch pushes are still blocked.
- AGENTS.md now says this.

## Testing

I fed the hook's stdin by hand with an unsigned commit:
- notes ref → exit 0
- tag ref → exit 0
- branch ref → exit 1 (rejected, same as before)
- branch ref with `CI=true` → exit 0

## Release note

This PR uses `fix:`, so merging it releases **v1.6.2**. That release includes the fast-uri fix that never shipped with v1.6.1. The `v1.6.1` tag stays behind with no GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
